### PR TITLE
譜面データをクリップボードから読み込めるようにする+α

### DIFF
--- a/src/components/editor/EditorController.vue
+++ b/src/components/editor/EditorController.vue
@@ -244,8 +244,15 @@ export default defineComponent({
 
     writeClipBoard(data: string, message: string): void {
       if (navigator.clipboard) {
-        navigator.clipboard.writeText(data);
-        alert(message);
+        navigator.clipboard.writeText(data).then(
+          // 成功時
+          () => alert(message),
+          // 失敗時
+          () =>
+            alert("クリップボードにコピーできませんでした。権限がありません。")
+        );
+      } else {
+        alert("クリップボードにコピーできませんでした。非対応のブラウザです。");
       }
     },
 

--- a/src/components/editor/service/ScoreRevivalService.ts
+++ b/src/components/editor/service/ScoreRevivalService.ts
@@ -87,7 +87,7 @@ export class ScoreRevivalService {
           keyNameWithNum.replace(scoreNumber.toString(), "")
         )
         .map((keyName: string) =>
-          dict[keyName]
+          (dict[keyName] ?? "")
             .split(",")
             .filter((x) => x)
             .map((x: string) => Number(x))

--- a/src/components/start/StartMain.vue
+++ b/src/components/start/StartMain.vue
@@ -104,7 +104,11 @@ export default defineComponent({
     onFileRecieve(file: File, errorMessage: string) {
       if (file.type.match("audio.*")) {
         this.readMusicFile(file);
-      } else if (file.type.match("(application/json|text/plain)")) {
+      } else if (
+        file.type.match(
+          "application/json|application/x-javascript|text/html|text/plain"
+        )
+      ) {
         this.readScoreFile(file);
       } else {
         alert(errorMessage);

--- a/src/components/start/StartMain.vue
+++ b/src/components/start/StartMain.vue
@@ -99,8 +99,35 @@ export default defineComponent({
   },
   mounted() {
     sessionStorage.removeItem("keyKind");
+    document.addEventListener("keydown", this.keydownAction);
+  },
+  unmounted() {
+    document.removeEventListener("keydown", this.keydownAction);
   },
   methods: {
+    keydownAction(e: KeyboardEvent) {
+      if (e.ctrlKey && e.code === "KeyV") {
+        if (navigator.clipboard) {
+          navigator.clipboard.readText().then(
+            // 成功時
+            (text) => {
+              if (text !== "") {
+                this.scoreDataStr = text;
+                this.scoreTitle = "(クリップボードから読込)";
+              } else {
+                alert("クリップボードが空か、テキストデータではありません。");
+              }
+            },
+            // 失敗時
+            () =>
+              alert("クリップボードを読み込めませんでした。権限がありません。")
+          );
+          e.preventDefault();
+        }
+      } else {
+        alert("クリップボードを読み込めませんでした。非対応のブラウザです。");
+      }
+    },
     onFileRecieve(file: File, errorMessage: string) {
       if (file.type.match("audio.*")) {
         this.readMusicFile(file);

--- a/src/components/start/StartMain.vue
+++ b/src/components/start/StartMain.vue
@@ -101,37 +101,42 @@ export default defineComponent({
     sessionStorage.removeItem("keyKind");
   },
   methods: {
-    onMusicFileRecieve(file: File) {
-      const mimeTypePattern = "audio.*";
-      if (!file.type.match(mimeTypePattern))
-        alert("音楽ファイルではありません。");
-      else {
-        const reader = new FileReader();
-        reader.onload = () => {
-          const result = reader.result;
-          if (typeof result == "string") {
-            this.musicUrl = result;
-            this.musicTitle = file.name;
-          }
-        };
-        reader.readAsDataURL(file);
+    onFileRecieve(file: File, errorMessage: string) {
+      if (file.type.match("audio.*")) {
+        this.readMusicFile(file);
+      } else if (file.type.match("(application/json|text/plain)")) {
+        this.readScoreFile(file);
+      } else {
+        alert(errorMessage);
       }
     },
+    onMusicFileRecieve(file: File) {
+      this.onFileRecieve(file, "音楽ファイルではありません。");
+    },
     onScoreFileRecieve(file: File) {
-      const mimeTypePattern = "(application/json|text/plain)";
-      if (!file.type.match(mimeTypePattern))
-        alert("譜面ファイルではありません。");
-      else {
-        const reader = new FileReader();
-        reader.onload = () => {
-          const result = reader.result;
-          if (typeof result == "string") {
-            this.scoreDataStr = result;
-            this.scoreTitle = file.name;
-          }
-        };
-        reader.readAsText(file);
-      }
+      this.onFileRecieve(file, "譜面ファイルではありません。");
+    },
+    readMusicFile(file: File) {
+      const reader = new FileReader();
+      reader.onload = () => {
+        const result = reader.result;
+        if (typeof result == "string") {
+          this.musicUrl = result;
+          this.musicTitle = file.name;
+        }
+      };
+      reader.readAsDataURL(file);
+    },
+    readScoreFile(file: File) {
+      const reader = new FileReader();
+      reader.onload = () => {
+        const result = reader.result;
+        if (typeof result == "string") {
+          this.scoreDataStr = result;
+          this.scoreTitle = file.name;
+        }
+      };
+      reader.readAsText(file);
     },
     moveToEditor(scoreData: string, musicUrl: string, key: string) {
       this.$router.push({


### PR DESCRIPTION
issue #60 の対応と、その他入出力周りの細かい改善です。

- [譜面データをクリップボードから読み込めるようにする](https://github.com/superkuppabros/danoni-editor/commit/d93c6a101ea8e40d9c90940c0e24d28b07af67ba)
  - StartページでCtrl+Vで貼り付けられるようにしました。
- [クリップボード書き込み時のメッセージを書き込み完了時に表示するように修正](https://github.com/superkuppabros/danoni-editor/commit/973fa7e1829aa1070bdada3bd35a9b578eef4895)
  - "コピーしました"が表示された時点ではコピーされていなかったのを修正しました。
  - また、エラーメッセージを追加しました。
- [dosの変数が足りなくても読み込めるようにする](https://github.com/superkuppabros/danoni-editor/commit/fe0e90ca97b403012f465eb9ccf79524a3e6531a)
  - dosからの復元時、変数(left_dataなど)が欠けていても読み込めるようにしました。
  - [bms to dos converter](http://www.omission0.com/other/b2dc/)などがノートのないキーを省略するためです。
- [譜面ファイルとして認識するMIMEタイプを追加](https://github.com/superkuppabros/danoni-editor/commit/b8463c6e47724893e55195592049255875b87d97)
  - \*.jsや\*.htmlを読み込めるようにしました。
- [音楽/譜面ファイルを逆にドロップしても受け付けるようにする](https://github.com/superkuppabros/danoni-editor/commit/936c9b5aaed20d64521a9516e359aa559ad527c8)
  - 楽曲ファイルの欄に譜面ファイルをドロップしたり、譜面ファイルの欄に楽曲ファイルをドロップしても読み込めるようにしました。
  - 時々間違えるので……。