### PR TITLE
ページ端での同時押し入力時に不正な場所にノートが置かれてしまう場合がある不具合の修正

### DIFF
--- a/src/components/editor/EditorMain.vue
+++ b/src/components/editor/EditorMain.vue
@@ -406,12 +406,11 @@ export default defineComponent({
 
     // 現在位置の上下移動
     currentPositionIncrease() {
-      this.currentPosition += this.divisor;
       const threshold: number = JSON.parse(localStorage.getItem("simultaneousThreshold") ?? "30");
-      if (this.currentPosition >= verticalSizeNum) {
+      if (this.currentPosition + this.divisor >= verticalSizeNum) {
         setTimeout(() => this.pagePlus(1), threshold);
       } else {
-        this.currentPositionService.move(this.currentPosition, this.page, this.timing);
+        this.currentPositionService.move(this.currentPosition + this.divisor, this.page, this.timing);
       }
     },
 


### PR DESCRIPTION
position=384の位置にノートが置かれてしまう場合があるようです。
https://twitter.com/tseirproodni/status/1525331522819002369

再現できていないのですが、おそらく#89 が原因の不具合で、以下のように発生します。
1. ページの終端で入力して`this.currentPosition += this.divisor`でcurrentPosition=384になる
2. `setTimeout(() => this.pagePlus(1), threshold)`が働く直前に次のノートを入力する
3. タイミングによって同時押しとして判定されなかった場合、position=384にノートが追加される

加算する処理の位置を変えてcurrentPosition=384にならないように修正しました。