### PR TITLE
楽曲読み込みの非同期化

### DIFF
--- a/src/components/editor/EditorMain.vue
+++ b/src/components/editor/EditorMain.vue
@@ -176,8 +176,11 @@ export default defineComponent({
     this.notesLayer = notesLayer;
 
     if (this.loadMusicUrl) {
-      const arrayBuffer = await fetch(this.loadMusicUrl).then((response) => response.arrayBuffer());
-      this.musicService = new MusicService(arrayBuffer);
+      fetch(this.loadMusicUrl)
+        .then((response) => response.arrayBuffer())
+        .then((buffer) => {
+          this.musicService = new MusicService(buffer);
+        });
     }
 
     this.noteService = new NoteService(
@@ -314,6 +317,8 @@ export default defineComponent({
 
     // 音楽再生処理
     playMusicLoop(timing: Timing) {
+      if (!this.musicService || !this.musicService.canPlay) return;
+
       const startPosition = -verticalSizeNum / 4;
       const endPosition = verticalSizeNum;
       const startTime = positionToSeconds(timing, this.page, startPosition);

--- a/src/components/editor/service/MusicService.ts
+++ b/src/components/editor/service/MusicService.ts
@@ -1,4 +1,5 @@
 export class MusicService {
+  public canPlay: boolean;
   private context: AudioContext = new AudioContext();
   private gainNode: GainNode;
   private buffer!: AudioBuffer;
@@ -8,9 +9,13 @@ export class MusicService {
     const gainNode = this.context.createGain();
     gainNode.connect(this.context.destination);
     this.gainNode = gainNode;
+    this.canPlay = false;
     this.context.decodeAudioData(
       arrayBuffer,
-      (buffer) => (this.buffer = buffer),
+      (buffer) => {
+        this.buffer = buffer;
+        this.canPlay = true;
+      },
       () => {
         throw "failed loading music.";
       }
@@ -26,6 +31,10 @@ export class MusicService {
    * @param musicRate 速度(0.25-2)
    */
   play(startTime: number, duration: number, musicVolume: number, musicRate: number): void {
+    if (!this.buffer) {
+      return;
+    }
+
     this.source = this.context.createBufferSource();
     this.source.buffer = this.buffer;
     this.source.connect(this.gainNode);


### PR DESCRIPTION
重い楽曲ファイルを読み込むと一瞬固まるので非同期にしました。
読み込み完了前はEnterを押しても再生しないようにしています。