### PR TITLE
音楽再生していないときにMusic Speedを変更すると再生が始まってしまう不具合の修正

### DIFF
--- a/src/components/editor/EditorMain.vue
+++ b/src/components/editor/EditorMain.vue
@@ -143,13 +143,11 @@ export default defineComponent({
     },
 
     musicRate() {
-      if (this.musicService) {
-        if (this.musicTimer) {
-          this.stopMusicLoop(this.musicTimer);
-        }
+      if (this.musicService && this.musicTimer) {
+        this.stopMusicLoop(this.musicTimer);
         this.playMusicLoop(this.timing);
       }
-    },
+    }
   },
 
   async mounted() {


### PR DESCRIPTION
#99 の修正です。条件分岐が間違っていました。