### PR TITLE
feat: 同一キーで表示レーンをショートカットで切替できる機能を実装

### DIFF
--- a/src/components/editor/EditorController.vue
+++ b/src/components/editor/EditorController.vue
@@ -179,12 +179,12 @@ export default defineComponent({
       scoreData.scores.push(new DefaultPageScore(keyNum));
     }
 
-    // ordersを指定することで初期の位置を入れ替える
+    // orderを指定することで初期の位置を入れ替える
     scoreData.scores.forEach((scoreList, j) => {
-      if (scoreData.orders !== undefined) {
+      if (scoreData.order !== undefined) {
         const notes: number[][] = [...Array(keyNum)].map(() => []);
         const freezes: number[][] = [...Array(keyNum)].map(() => []);
-        scoreData.orders.forEach((val, k) => {
+        scoreData.order.forEach((val, k) => {
           notes[val] = scoreList.notes[k];
           freezes[val] = scoreList.freezes[k];
         });
@@ -192,7 +192,7 @@ export default defineComponent({
         scoreData.scores[j].freezes = freezes;
       }
     });
-    scoreData.orders = undefined;
+    scoreData.order = undefined;
 
     return {
       pageNum: 1,

--- a/src/components/editor/EditorController.vue
+++ b/src/components/editor/EditorController.vue
@@ -164,6 +164,21 @@ export default defineComponent({
       scoreData.scores.push(new DefaultPageScore(keyNum));
     }
 
+    // ordersを指定することで初期の位置を入れ替える
+    scoreData.scores.forEach((scoreList, j) => {
+      if (scoreData.orders !== undefined) {
+        const notes: number[][] = [...Array(keyNum)].map(() => []);
+        const freezes: number[][] = [...Array(keyNum)].map(() => []);
+        scoreData.orders.forEach((val, k) => {
+          notes[val] = scoreList.notes[k];
+          freezes[val] = scoreList.freezes[k];
+        });
+        scoreData.scores[j].notes = notes;
+        scoreData.scores[j].freezes = freezes;
+      }
+    });
+    scoreData.orders = undefined;
+
     return {
       pageNum: 1,
       labelNum: 1,

--- a/src/components/editor/EditorMain.vue
+++ b/src/components/editor/EditorMain.vue
@@ -98,7 +98,7 @@ export default defineComponent({
     const operationStack: Operation[] = [];
     const defaultOrder: number[][] = [[...Array(keyConfig[keyKind].num)].map((_: undefined, idx: number) => idx)];
     const orderGroups: number[][] =
-      keyConfig[keyKind]?.orderGroup !== undefined ? defaultOrder.concat(keyConfig[keyKind]?.orderGroup ?? []) : defaultOrder;
+      keyConfig[keyKind]?.orderGroups !== undefined ? defaultOrder.concat(keyConfig[keyKind]?.orderGroups ?? []) : defaultOrder;
 
     return {
       currentPosition: 0,
@@ -407,17 +407,17 @@ export default defineComponent({
       const orderGroup: number[] = this.orderGroups[this.orderGroupNo];
 
       pageScore.notes.forEach((laneArr, lane) => {
-        const convLane = orderGroup.indexOf(lane);
+        const orgLane = orderGroup.indexOf(lane);
         laneArr.forEach((position) => {
-          noteService.draw(lane, position, false, convLane);
+          noteService.draw(lane, position, false, orgLane);
         });
       });
       pageScore.freezes.forEach((laneArr, lane) => {
-        const convLane = orderGroup.indexOf(lane);
+        const orgLane = orderGroup.indexOf(lane);
         laneArr.forEach((position) => {
-          noteService.draw(lane, position, true, convLane);
+          noteService.draw(lane, position, true, orgLane);
         });
-        noteService.fillFreeze(this.page, convLane);
+        noteService.fillFreeze(this.page, orgLane, lane);
       });
       pageScore.speeds.forEach((speed) => {
         speedPieceService.draw(speed.position, speed.type);
@@ -635,7 +635,7 @@ export default defineComponent({
             let isSimultaneous = false;
 
             const orderGroup: number[] = this.orderGroups[this.orderGroupNo];
-            const convLane = orderGroup.indexOf(possiblyLane);
+            const orgLane = orderGroup.indexOf(possiblyLane);
             if (possiblyLane >= 0) {
               // 一定時間内に押されたときは直前の位置にノートを追加/削除する
               const now = new Date();
@@ -651,9 +651,9 @@ export default defineComponent({
 
               // ノートの追加/削除
               if (noteService.hasNote(page, possiblyLane, position).exists) {
-                noteService.removeOne(page, this.page, possiblyLane, position, convLane);
+                noteService.removeOne(page, this.page, possiblyLane, position, orgLane);
               } else {
-                noteService.addOne(page, this.page, possiblyLane, position, isFreeze, convLane);
+                noteService.addOne(page, this.page, possiblyLane, position, isFreeze, orgLane);
               }
 
               // 同時押しのときはカーソルを進めない

--- a/src/components/editor/EditorMain.vue
+++ b/src/components/editor/EditorMain.vue
@@ -70,6 +70,10 @@ type DataType = {
   previousDate: Date;
   orderGroups: number[][];
   orderGroupNo: number;
+  keysFull: string[][];
+  charsFull: string[][];
+  alternativeKeysFull: string[][];
+  orderKeyTypes: number[];
 };
 
 export default defineComponent({
@@ -100,6 +104,26 @@ export default defineComponent({
     const orderGroups: number[][] =
       keyConfig[keyKind]?.orderGroups !== undefined ? defaultOrder.concat(keyConfig[keyKind]?.orderGroups ?? []) : defaultOrder;
 
+    // 対応キーの全パターンを取得
+    const keysFull: string[][] =
+      keyConfig[keyKind]?.keysEtc !== undefined
+        ? [keyConfig[keyKind].keys].concat(keyConfig[keyKind]?.keysEtc ?? [])
+        : [keyConfig[keyKind].keys];
+    const alternativeKeysFull: string[][] =
+      keyConfig[keyKind]?.alternativeKeysEtc !== undefined
+        ? [keyConfig[keyKind].alternativeKeys].concat(keyConfig[keyKind]?.alternativeKeysEtc ?? [])
+        : [keyConfig[keyKind].alternativeKeys];
+
+    // 画面に表示するキーの全パターンを取得
+    let charsFull: string[][] = [[]];
+    const chars = keyConfig[keyKind].chars ?? [];
+    const charsEtc = keyConfig[keyKind]?.charsEtc ?? [];
+    if (chars.length > 0) charsFull = [chars];
+    if (charsEtc.length > 0) charsFull.push(...charsEtc);
+
+    const orderKeyTypes: number[] =
+      keyConfig[keyKind]?.orderKeyTypes !== undefined ? [0].concat(keyConfig[keyKind]?.orderKeyTypes ?? []) : [0];
+
     return {
       currentPosition: 0,
       scoreData,
@@ -118,6 +142,10 @@ export default defineComponent({
       previousDate: new Date(0),
       orderGroups,
       orderGroupNo: 0,
+      keysFull,
+      charsFull,
+      alternativeKeysFull,
+      orderKeyTypes,
     };
   },
 
@@ -255,6 +283,7 @@ export default defineComponent({
 
       // 縦罫線の描画
       const orderGroup: number[] = this.orderGroups[this.orderGroupNo];
+      const orderKeyType: number = this.orderKeyTypes[this.orderGroupNo] ?? 0;
       for (let lane = 0; lane < keyNum; lane++) {
         const convLane = orderGroup[lane];
         const xPos = (lane + 1) * noteWidth;
@@ -329,7 +358,7 @@ export default defineComponent({
         const colorGroup = keyConfig.colorGroup;
         const color = noteColors[colorGroup[convLane]];
 
-        const chars = keyConfig.chars;
+        const chars = this.charsFull[orderKeyType];
 
         if (chars) {
           const charStr = chars[convLane];
@@ -624,9 +653,10 @@ export default defineComponent({
             break;
 
           default: {
+            const orderKeyType: number = this.orderKeyTypes[this.orderGroupNo] ?? 0;
             const possiblyLane = Math.max(
-              this.keyConfig[this.keyKind].keys.indexOf(e.code),
-              this.keyConfig[this.keyKind].alternativeKeys.indexOf(e.code)
+              this.keysFull[orderKeyType].indexOf(e.code),
+              this.alternativeKeysFull[orderKeyType].indexOf(e.code)
             );
             const isFreeze = e.shiftKey;
 

--- a/src/components/editor/EditorMain.vue
+++ b/src/components/editor/EditorMain.vue
@@ -101,18 +101,15 @@ export default defineComponent({
     const pageBlockNum = parseInt(JSON.parse(localStorage.getItem("pageBlockNum") ?? "8"));
     const operationStack: Operation[] = [];
     const defaultOrder: number[][] = [[...Array(keyConfig[keyKind].num)].map((_: undefined, idx: number) => idx)];
-    const orderGroups: number[][] =
-      keyConfig[keyKind]?.orderGroups !== undefined ? defaultOrder.concat(keyConfig[keyKind]?.orderGroups ?? []) : defaultOrder;
+    const orderGroups: number[][] = defaultOrder.concat(keyConfig[keyKind]?.orderGroups ?? []).filter((val) => val.length > 0);
 
     // 対応キーの全パターンを取得
-    const keysFull: string[][] =
-      keyConfig[keyKind]?.keysEtc !== undefined
-        ? [keyConfig[keyKind].keys].concat(keyConfig[keyKind]?.keysEtc ?? [])
-        : [keyConfig[keyKind].keys];
-    const alternativeKeysFull: string[][] =
-      keyConfig[keyKind]?.alternativeKeysEtc !== undefined
-        ? [keyConfig[keyKind].alternativeKeys].concat(keyConfig[keyKind]?.alternativeKeysEtc ?? [])
-        : [keyConfig[keyKind].alternativeKeys];
+    const keysFull: string[][] = [keyConfig[keyKind].keys]
+      .concat(keyConfig[keyKind]?.keysEtc ?? [])
+      .filter((val) => val.length > 0);
+    const alternativeKeysFull: string[][] = [keyConfig[keyKind].alternativeKeys]
+      .concat(keyConfig[keyKind]?.alternativeKeysEtc ?? [])
+      .filter((val) => val.length > 0);
 
     // 画面に表示するキーの全パターンを取得
     let charsFull: string[][] = [[]];

--- a/src/components/editor/EditorMain.vue
+++ b/src/components/editor/EditorMain.vue
@@ -417,7 +417,7 @@ export default defineComponent({
         laneArr.forEach((position) => {
           noteService.draw(lane, position, true, orgLane);
         });
-        noteService.fillFreeze(this.page, orgLane, lane);
+        noteService.fillFreeze(this.page, lane, orgLane);
       });
       pageScore.speeds.forEach((speed) => {
         speedPieceService.draw(speed.position, speed.type);

--- a/src/components/editor/service/NoteService.ts
+++ b/src/components/editor/service/NoteService.ts
@@ -87,7 +87,7 @@ export class NoteService {
     if (page === displayPage) {
       this.draw(lane, position, isFreeze, orgLane);
     }
-    if (isFreeze) this.fillFreeze(displayPage, orgLane, lane);
+    if (isFreeze) this.fillFreeze(displayPage, lane, orgLane);
     this.stackPush({
       type: "ADD_NOTE",
       page,
@@ -105,7 +105,7 @@ export class NoteService {
     if (page === displayPage) {
       this.clear(orgLane, position);
     }
-    this.fillFreeze(displayPage, orgLane, lane);
+    this.fillFreeze(displayPage, lane, orgLane);
     this.stackPush({
       type: "REMOVE_NOTE",
       page,
@@ -116,25 +116,25 @@ export class NoteService {
   }
 
   // フリーズの塗りつぶし描画
-  fillFreeze(page: number, lane: number, viewLane: number = lane) {
+  fillFreeze(page: number, lane: number, orgLane: number = lane) {
     if (!this.isHighlightedFreeze) return false;
     const stage = this.stage;
     const notesLayer = this.notesLayer;
 
     const colorGroup = this.keyConfig[this.keyKind].colorGroup;
-    const color = freezeColors[colorGroup[viewLane]];
+    const color = freezeColors[colorGroup[lane]];
 
-    const laneFreezes: number[] = cloneDeep(this.scoreData.scores[page - 1].freezes[viewLane]).sort((a, b) => a - b);
+    const laneFreezes: number[] = cloneDeep(this.scoreData.scores[page - 1].freezes[lane]).sort((a, b) => a - b);
 
     const startParity =
       this.scoreData.scores.reduce((acc, score, index) => {
-        return index < page - 1 ? acc + score.freezes[viewLane].length : acc;
+        return index < page - 1 ? acc + score.freezes[lane].length : acc;
       }, 0) % 2;
 
     if (startParity === 1) laneFreezes.unshift(0);
     laneFreezes.push(verticalSizeNum(this.pageBlockNum));
 
-    const freezeClass = `.freeze-fill-${viewLane}`;
+    const freezeClass = `.freeze-fill-${lane}`;
     const fills = notesLayer.find(freezeClass);
     fills.forEach((node) => node.destroy());
 
@@ -145,14 +145,14 @@ export class NoteService {
       const opacity = 0.3;
 
       const fillFreeze = new Konva.Rect({
-        x: lane * noteWidth,
+        x: orgLane * noteWidth,
         y: Math.min(toPx(freezeStart, this.isReverse), toPx(freezeEnd, this.isReverse)),
         width: noteWidth,
         height,
         opacity,
         fill: color,
-        name: `freeze-fill-${viewLane}`,
-        id: `freeze-fill-${viewLane}-${freezeStart}`,
+        name: `freeze-fill-${lane}`,
+        id: `freeze-fill-${lane}-${freezeStart}`,
       });
       notesLayer.add(fillFreeze);
     }

--- a/src/components/editor/service/NoteService.ts
+++ b/src/components/editor/service/NoteService.ts
@@ -134,7 +134,7 @@ export class NoteService {
     if (startParity === 1) laneFreezes.unshift(0);
     laneFreezes.push(verticalSizeNum(this.pageBlockNum));
 
-    const freezeClass = `.freeze-fill-${lane}`;
+    const freezeClass = `.freeze-fill-${orgLane}`;
     const fills = notesLayer.find(freezeClass);
     fills.forEach((node) => node.destroy());
 
@@ -151,8 +151,8 @@ export class NoteService {
         height,
         opacity,
         fill: color,
-        name: `freeze-fill-${lane}`,
-        id: `freeze-fill-${lane}-${freezeStart}`,
+        name: `freeze-fill-${orgLane}`,
+        id: `freeze-fill-${orgLane}-${freezeStart}`,
       });
       notesLayer.add(fillFreeze);
     }

--- a/src/components/editor/service/NoteService.ts
+++ b/src/components/editor/service/NoteService.ts
@@ -52,7 +52,7 @@ export class NoteService {
   }
 
   // ノーツの描画
-  draw(lane: number, position: number, isFreeze: boolean, viewLane: number = lane): void {
+  draw(lane: number, position: number, isFreeze: boolean, orgLane: number = lane): void {
     const stage = this.stage as Konva.Stage;
     const notesLayer = this.notesLayer as Konva.Layer;
 
@@ -60,12 +60,12 @@ export class NoteService {
     const color = isFreeze ? freezeColors[colorGroup[lane]] : noteColors[colorGroup[lane]];
 
     const note = new Konva.Rect({
-      x: viewLane * noteWidth,
+      x: orgLane * noteWidth,
       y: toPx(position, this.isReverse) - noteHeight / 2,
       width: noteWidth,
       height: noteHeight,
       fill: color,
-      id: `note-${viewLane}-${position}`,
+      id: `note-${orgLane}-${position}`,
     });
     notesLayer.add(note);
     stage.add(notesLayer);
@@ -82,12 +82,12 @@ export class NoteService {
   }
 
   // 1ノーツを追加して描画
-  addOne(page: number, displayPage: number, lane: number, position: number, isFreeze: boolean, viewLane: number = lane) {
+  addOne(page: number, displayPage: number, lane: number, position: number, isFreeze: boolean, orgLane: number = lane) {
     this.add(page, lane, position, isFreeze);
     if (page === displayPage) {
-      this.draw(lane, position, isFreeze, viewLane);
+      this.draw(lane, position, isFreeze, orgLane);
     }
-    if (isFreeze) this.fillFreeze(displayPage, lane);
+    if (isFreeze) this.fillFreeze(displayPage, orgLane, lane);
     this.stackPush({
       type: "ADD_NOTE",
       page,
@@ -98,14 +98,14 @@ export class NoteService {
   }
 
   // 1ノーツを削除してクリア
-  removeOne(page: number, displayPage: number, lane: number, position: number, viewLane: number = lane) {
+  removeOne(page: number, displayPage: number, lane: number, position: number, orgLane: number = lane) {
     const { isFreeze } = this.hasNote(page, lane, position);
 
     this.remove(page, lane, position);
     if (page === displayPage) {
-      this.clear(viewLane, position);
+      this.clear(orgLane, position);
     }
-    this.fillFreeze(displayPage, viewLane);
+    this.fillFreeze(displayPage, orgLane, lane);
     this.stackPush({
       type: "REMOVE_NOTE",
       page,
@@ -116,25 +116,25 @@ export class NoteService {
   }
 
   // フリーズの塗りつぶし描画
-  fillFreeze(page: number, lane: number) {
+  fillFreeze(page: number, lane: number, viewLane: number = lane) {
     if (!this.isHighlightedFreeze) return false;
     const stage = this.stage;
     const notesLayer = this.notesLayer;
 
     const colorGroup = this.keyConfig[this.keyKind].colorGroup;
-    const color = freezeColors[colorGroup[lane]];
+    const color = freezeColors[colorGroup[viewLane]];
 
-    const laneFreezes: number[] = cloneDeep(this.scoreData.scores[page - 1].freezes[lane]).sort((a, b) => a - b);
+    const laneFreezes: number[] = cloneDeep(this.scoreData.scores[page - 1].freezes[viewLane]).sort((a, b) => a - b);
 
     const startParity =
       this.scoreData.scores.reduce((acc, score, index) => {
-        return index < page - 1 ? acc + score.freezes[lane].length : acc;
+        return index < page - 1 ? acc + score.freezes[viewLane].length : acc;
       }, 0) % 2;
 
     if (startParity === 1) laneFreezes.unshift(0);
     laneFreezes.push(verticalSizeNum(this.pageBlockNum));
 
-    const freezeClass = `.freeze-fill-${lane}`;
+    const freezeClass = `.freeze-fill-${viewLane}`;
     const fills = notesLayer.find(freezeClass);
     fills.forEach((node) => node.destroy());
 
@@ -151,8 +151,8 @@ export class NoteService {
         height,
         opacity,
         fill: color,
-        name: `freeze-fill-${lane}`,
-        id: `freeze-fill-${lane}-${freezeStart}`,
+        name: `freeze-fill-${viewLane}`,
+        id: `freeze-fill-${viewLane}-${freezeStart}`,
       });
       notesLayer.add(fillFreeze);
     }

--- a/src/components/editor/service/NoteService.ts
+++ b/src/components/editor/service/NoteService.ts
@@ -17,7 +17,7 @@ export class NoteService {
     private stage: Konva.Stage,
     private notesLayer: Konva.Layer,
     private operationStack: Operation[]
-  ) {}
+  ) { }
 
   private keyNum = this.keyConfig[this.keyKind].num;
   private isHighlightedFreeze: string = JSON.parse(localStorage.getItem("isHighlightedFreeze") ?? "true");
@@ -52,7 +52,7 @@ export class NoteService {
   }
 
   // ノーツの描画
-  draw(lane: number, position: number, isFreeze: boolean): void {
+  draw(lane: number, position: number, isFreeze: boolean, viewLane: number = lane): void {
     const stage = this.stage as Konva.Stage;
     const notesLayer = this.notesLayer as Konva.Layer;
 
@@ -60,12 +60,12 @@ export class NoteService {
     const color = isFreeze ? freezeColors[colorGroup[lane]] : noteColors[colorGroup[lane]];
 
     const note = new Konva.Rect({
-      x: lane * noteWidth,
+      x: viewLane * noteWidth,
       y: toPx(position, this.isReverse) - noteHeight / 2,
       width: noteWidth,
       height: noteHeight,
       fill: color,
-      id: `note-${lane}-${position}`,
+      id: `note-${viewLane}-${position}`,
     });
     notesLayer.add(note);
     stage.add(notesLayer);
@@ -82,10 +82,10 @@ export class NoteService {
   }
 
   // 1ノーツを追加して描画
-  addOne(page: number, displayPage: number, lane: number, position: number, isFreeze: boolean) {
+  addOne(page: number, displayPage: number, lane: number, position: number, isFreeze: boolean, viewLane: number = lane) {
     this.add(page, lane, position, isFreeze);
     if (page === displayPage) {
-      this.draw(lane, position, isFreeze);
+      this.draw(lane, position, isFreeze, viewLane);
     }
     if (isFreeze) this.fillFreeze(displayPage, lane);
     this.stackPush({
@@ -98,14 +98,14 @@ export class NoteService {
   }
 
   // 1ノーツを削除してクリア
-  removeOne(page: number, displayPage: number, lane: number, position: number) {
+  removeOne(page: number, displayPage: number, lane: number, position: number, viewLane: number = lane) {
     const { isFreeze } = this.hasNote(page, lane, position);
 
     this.remove(page, lane, position);
     if (page === displayPage) {
-      this.clear(lane, position);
+      this.clear(viewLane, position);
     }
-    this.fillFreeze(displayPage, lane);
+    this.fillFreeze(displayPage, viewLane);
     this.stackPush({
       type: "REMOVE_NOTE",
       page,

--- a/src/model/KeyConfig.ts
+++ b/src/model/KeyConfig.ts
@@ -10,7 +10,7 @@ export type KeyConfig = {
     noteNames: string[];
     freezeNames: string[];
     colorGroup: number[];
-    orderGroup?: number[][];
+    orderGroups?: number[][];
   };
 };
 
@@ -24,7 +24,7 @@ export type CustomKeyConfig = {
     noteNames: string[];
     freezeNames: string[];
     colorGroup: number[];
-    orderGroup?: number[][];
+    orderGroups?: number[][];
   };
 };
 
@@ -38,7 +38,7 @@ export const DefaultKeyConfig: KeyConfig = {
     noteNames: ["left_data", "down_data", "up_data", "right_data", "space_data"],
     freezeNames: ["frzLeft_data", "frzDown_data", "frzUp_data", "frzRight_data", "frzSpace_data"],
     colorGroup: [0, 0, 0, 0, 2],
-    orderGroup: [[4, 0, 1, 2, 3], [0, 1, 4, 2, 3]],
+    orderGroups: [[4, 0, 1, 2, 3], [0, 1, 4, 2, 3]],
   },
 
   "7": {
@@ -279,7 +279,7 @@ export const DefaultKeyConfig: KeyConfig = {
       "sfrzRight_data",
     ],
     colorGroup: [0, 1, 0, 2, 0, 1, 0, 2, 3, 3, 2],
-    orderGroup: [[7, 0, 1, 2, 8, 3, 9, 4, 5, 6, 10]],
+    orderGroups: [[7, 0, 1, 2, 8, 3, 9, 4, 5, 6, 10]],
   },
 
   "11i": {

--- a/src/model/KeyConfig.ts
+++ b/src/model/KeyConfig.ts
@@ -10,6 +10,7 @@ export type KeyConfig = {
     noteNames: string[];
     freezeNames: string[];
     colorGroup: number[];
+    orderGroup?: number[][];
   };
 };
 
@@ -23,6 +24,7 @@ export type CustomKeyConfig = {
     noteNames: string[];
     freezeNames: string[];
     colorGroup: number[];
+    orderGroup?: number[][];
   };
 };
 
@@ -36,6 +38,7 @@ export const DefaultKeyConfig: KeyConfig = {
     noteNames: ["left_data", "down_data", "up_data", "right_data", "space_data"],
     freezeNames: ["frzLeft_data", "frzDown_data", "frzUp_data", "frzRight_data", "frzSpace_data"],
     colorGroup: [0, 0, 0, 0, 2],
+    orderGroup: [[4, 0, 1, 2, 3], [0, 1, 4, 2, 3]],
   },
 
   "7": {
@@ -276,6 +279,7 @@ export const DefaultKeyConfig: KeyConfig = {
       "sfrzRight_data",
     ],
     colorGroup: [0, 1, 0, 2, 0, 1, 0, 2, 3, 3, 2],
+    orderGroup: [[7, 0, 1, 2, 8, 3, 9, 4, 5, 6, 10]],
   },
 
   "11i": {

--- a/src/model/KeyConfig.ts
+++ b/src/model/KeyConfig.ts
@@ -7,10 +7,14 @@ export type KeyConfig = {
     keys: string[];
     chars?: string[];
     alternativeKeys: string[];
+    keysEtc?: string[][];
+    charsEtc?: string[][];
+    alternativeKeysEtc?: string[][];
     noteNames: string[];
     freezeNames: string[];
     colorGroup: number[];
     orderGroups?: number[][];
+    orderKeyTypes?: number[];
   };
 };
 
@@ -21,10 +25,14 @@ export type CustomKeyConfig = {
     keys: string[];
     chars?: string[];
     alternativeKeys: string[];
+    keysEtc?: string[][];
+    charsEtc?: string[][];
+    alternativeKeysEtc?: string[][];
     noteNames: string[];
     freezeNames: string[];
     colorGroup: number[];
     orderGroups?: number[][];
+    orderKeyTypes?: number[];
   };
 };
 
@@ -39,6 +47,11 @@ export const DefaultKeyConfig: KeyConfig = {
     freezeNames: ["frzLeft_data", "frzDown_data", "frzUp_data", "frzRight_data", "frzSpace_data"],
     colorGroup: [0, 0, 0, 0, 2],
     orderGroups: [[4, 0, 1, 2, 3], [0, 1, 4, 2, 3]],
+
+    keysEtc: [["KeyD", "KeyF", "KeyJ", "KeyK", "KeyG"]],
+    charsEtc: [["D", "F", "J", "K", "G"]],
+    alternativeKeysEtc: [["", "", "", "", "KeyH"]],
+    orderKeyTypes: [0, 1],
   },
 
   "7": {

--- a/src/model/ScoreData.ts
+++ b/src/model/ScoreData.ts
@@ -8,7 +8,7 @@ export interface ScoreData {
   timings: Timing[];
   scoreNumber?: number;
   scores: PageScore[];
-  orders?: number[];
+  order?: number[];
 }
 
 export class DefaultScoreData implements ScoreData {

--- a/src/model/ScoreData.ts
+++ b/src/model/ScoreData.ts
@@ -8,6 +8,7 @@ export interface ScoreData {
   timings: Timing[];
   scoreNumber?: number;
   scores: PageScore[];
+  orders?: number[];
 }
 
 export class DefaultScoreData implements ScoreData {


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
### 1. 同一キーで表示レーンをショートカットで切替できる機能の実装
- 「Ctrl」+「Q」キーでエディターの表示レーンを切替できる機能を実装しました。
- 現状、5keyと11Wkeyに対して設定しています。

### カスタムエディター定義方法
- 表示レーンを切り替える場合、orderGroupsという名前で二次元配列で指定します。
- 複数パターンの指定が可能で、元の順序に対してどう並び替えたいかを0からの数字で指定します。
- デフォルトは0～キー数分で、デフォルトのみの場合の指定は不要です。

```ts
"5": {
    id: 1,
    num: 5,
    keys: ["KeyJ", "KeyK", "KeyI", "KeyL", "KeyG"],
    chars: ["J", "K", "I", "L", "G"],
    alternativeKeys: ["KeyS", "KeyD", "KeyE", "KeyF", "KeyH"],
    noteNames: ["left_data", "down_data", "up_data", "right_data", "space_data"],
    freezeNames: ["frzLeft_data", "frzDown_data", "frzUp_data", "frzRight_data", "frzSpace_data"],
    colorGroup: [0, 0, 0, 0, 2],
    orderGroups: [[4, 0, 1, 2, 3], [0, 1, 4, 2, 3]],

    keysEtc: [["KeyD", "KeyF", "KeyJ", "KeyK", "KeyG"]],
    charsEtc: [["D", "F", "J", "K", "G"]],
    alternativeKeysEtc: [["", "", "", "", "KeyH"]],
    orderKeyTypes: [0, 1],
},
"7": {
    id: 2,
    num: 7,
    keys: ["KeyS", "KeyD", "KeyF", "KeyG", "KeyJ", "KeyK", "KeyL"],
    chars: ["S", "D", "F", "G", "J", "K", "L"],
    alternativeKeys: ["", "", "", "KeyH", "", "", ""],
    noteNames: ["left_data", "leftdia_data", "down_data", "space_data", "up_data", "rightdia_data", "right_data"],
    freezeNames: ["frzLeft_data", "frzLdia_data", "frzDown_data", "frzSpace_data", "frzUp_data", "frzRdia_data", "frzRight_data"],
    colorGroup: [0, 1, 0, 2, 0, 1, 0],
},
```

### 追加設定仕様
- 追加した設定は既存のものと競合しないように設定しています。
- 今回追加した設定は全て追加設定です。デフォルトの設定は「EditorMain.vue」内で補完処理を行っているため、
設定側で特別な設定は不要となっています。

|プロパティ名|データ型|必須|説明|
|----|----|----|----|
|orderGroups|二次元配列(数字)||表示レーンを元の順序に対してどのように変えるかを指定。複数記載可能。|
|keysEtc|二次元配列(文字列)||入力に使用するキーの [KeyboardEvent.code](https://developer.mozilla.org/ja/docs/Web/API/KeyboardEvent/code) の一覧（別バージョン）。複数記載可能。|
|charsEtc|二次元配列(文字列)||エディタ下部に表示する文字の一覧（別バージョン）。複数記載可能。|
|alternativeKeysEtc|二次元配列(文字列)||入力に使用する代替キーの [KeyboardEvent.code](https://developer.mozilla.org/ja/docs/Web/API/KeyboardEvent/code) の一覧（別バージョン）。複数記載可能。|
|orderKeyTypes|配列(数字)||orderGroups個別に、keys/keysEtcのどれを割り当てるかを指定。デフォルトは0。keysEtcから選ぶ場合、1以上の値を指定する。|

#### keysEtc, charsEtc, alternativeKeysEtc の並び順について
- 上記の5keyのcharsEtcは、`[["D", "F", "J", "K", "G"]],`となっています。
- 両手5keyなら「D F G(Space) J K」としたいところですが、これは元の表示レーンの順（J K I L G(Space)）に倣っているためです。あくまで元の表示のkeys/chars/alternativeKeysに対してどう変えたいかという設定をします。

### 2. ロード時にレーンを置き換える設定を追加
- セーブデータに「order」という設定を追加しました。使い方は「orderGroups」の1グループ分と同じです。
- キー別に設定されているデフォルトのレーン位置に対して、読込元のレーンをどのように再配置するかを設定します。
- セーブデータに出力されていないので、手動で設定を足すことでインポート時に反映します。
- 読み込んだ後は不要となるため、"order"の設定はリセットされるようにしています。
- 並び替えを想定した機能のため、読込元が1つに対して反映先が複数といったパターンは想定していません。

#### 使用例１：別表示モードからの互換
- `keyKind`の後ろに続けて設定します。
- 並び順を変えて取り込むので、逆順にすればミラー譜面として取込できます。
```ts
..., "keyKind": "5", "order": [0,1,4,2,3]}  // 両手5key用
..., "keyKind": "11W", "order": [7,0,1,2,8,3,9,4,5,6,10]}  // 11Wkeyの別表示モード用
```

#### 使用例２：5keyデータを9Akeyとしてコンバート
- `keyKind`を"5"から"9A"に変更し、`order`属性を追加した例です。
- 譜面の設定名（left_data, down_data, ...）に依存しません。
```ts
{"blankFrame":200,"timings":[{"label":1,"startNum":0,"bpm":140}],"scoreNumber":1,"scores":[{"speeds":[],"notes":[[0,120],[24,96,144,216],[72,192],[48,168],[240]],"freezes":[[],[],[],[],[]]}],"keyKind":"9A","order":[5,6,7,8,4]}
```

#### 使用例３－１：9Akeyデータを5keyにコンバート
- `keyKind`を"9A"から"5"に変更し、`order`属性を追加した例です。
- 5keyのどの部分にマッピングするかを指定します。同じ値があった場合は後に指定した方が有効となります。
```ts
{"blankFrame":200,"timings":[{"label":1,"startNum":0,"bpm":140}],"scoreNumber":1,"scores":[{"speeds":[],"notes":[[0],[24],[48],[72],[192],[96],[120],[144],[168]],"freezes":[[],[],[],[],[],[],[],[],[]]}],"keyKind":"5", "order":[0,0,0,0,4,0,1,2,3]}
```

#### 使用例３－２：9Akeyデータを5keyにコンバート(右半分をカット)
- 9Akeyの右半分を変換させたくないときは、一部だけを指定すればOKです。
```ts
{"blankFrame":200,"timings":[{"label":1,"startNum":0,"bpm":140}],"scoreNumber":1,"scores":[{"speeds":[],"notes":[[0],[24],[48],[72],[192],[96],[120],[144],[168]],"freezes":[[],[],[],[],[],[],[],[],[]]}],"keyKind":"5", "order":[0,1,2,3,4]}
```

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
1. 合作などで、5keyや11Wkeyのときに別表示モードを使用しているとエディター定義の切り替えが必要で、
都度差し替えが大変なため。
2. 1.に対するコンバートがあった方が良いと考えたため。
また、手動でも他キーコンバートできた方が後々便利だと思いました。
譜面復元機能でも似たようなことはできますが、譜面の設定名に依存しない分使いやすいと思います。

## :camera: スクリーンショット / Screenshot
- 5keyの場合、一番右のパターンのみ割り当てキーを変えるようにしています。
<img src="https://github.com/user-attachments/assets/4b5f7fd7-78d0-4931-bfcd-a6b2c52b2470" width="30%"><img src="https://github.com/user-attachments/assets/e4309124-fecc-4594-a6dd-0a5964da012c" width="30%"><img src="https://github.com/user-attachments/assets/a2420b04-8b6b-4822-aa99-56335dc79982" width="30%">

<img src="https://github.com/user-attachments/assets/392a32bb-e20b-4025-a337-b7354ca397be" width="50%"><img src="https://github.com/user-attachments/assets/157666cb-b004-445d-b6f3-8f7df952c820" width="50%">

## :pencil: その他コメント / Other Comments
- ショートカットキーの位置は片手で操作できれば良いと思っただけなのでこだわりはありません。
- 書き方としてまずい点などあればご指摘をお願いします。
- 現状の5key, 11Wkeyの別表示モードから自動で移行する機能は無いので、別表示モードのidや名前は他と区別した方が良いかもしれません。(とはいえ、フッター情報から復元できるので大半の場合は問題なさそうに思います)
⇒ 2. のコンバート方法で補完はできると考えています。

### 内部的な仕様変更点
#### EditorMain.vue
- 主に今回追加した設定のデフォルト値の定義を動的に追加しています。
この設定はEditorMain.vue内で行われるため、他の画面に引き継ぐ場合は値渡しが必要です。
ただ、今回の場合は特に他の画面やコントロールから参照するものは無かったので、特に定義していません。
  - keyConfig[keyKind].orderGroups のデフォルト値として `[0, 1, ..., keyNum-1]` の配列を自動追加し
`this.orderGroups`として定義。
  - keyConfig[keyKind].keys, keysEtcを配列結合して `this.keysFull` として定義。
  - keyConfig[keyKind].chars, charsEtcを配列結合して `this.charsFull` として定義。
  - keyConfig[keyKind].alternativeKeys, alternativeKeysEtcを配列結合して `this.alternativeKeysFull` として定義。
  - keyConfig[keyKind].orderKeyTypes のデフォルト値として `0`を自動追加し `this.orderKeyTypes` として定義。
⇒ `this.orderGroupNo`の値によりどのパターンになるかが決まる仕組みです。

- 見た目のレーン位置を設定するため、引数の追加を行っています。
下記どちらかに統一したかったのですが、描画順が正順で無い場合に罫線が濃く出てしまうので断念しました。
  1. 初期で与えられたレーン位置を`lane`としたとき、変換先を`convLane`として定義。（罫線描画・入力キー部分）
  1. レーン位置`lane`に対し、逆に元々のレーンを参照する場合は`orgLane`として定義。（ノーツ配置部分）

- 対応キーの動的変更に合わせ、キー入力箇所・キー表示箇所を下記の通り変更しました。
  - `this.keyConfig[this.keyKind].keys` -> `this.keysFull[orderKeyType]`
  - `this.keyConfig[this.keyKind].alternativeKeys` -> `this.alternativeKeysFull[orderKeyType]`
  - `this.keyConfig.chars` -> `this.charsFull[orderKeyType]`

- ショートカットキー「Ctrl」+「Q」の追加
  - 頻繁に変えるものではないので、`mustCtrlAction`に追加しました。

#### NotesService.ts
- EditorMain.vueから呼び出される各種関数への対応が主です。
全体的に `orgLane`という引数を追加しています。（念のためデフォルト値として `lane`をセット）

#### KeyConfig.ts
- 「keysEtc」「charsEtc」「alternativeKeysEtc」「orderGroups」「orderKeyTypes」を追加しました。
- 5key, 11Wkeyに対して設定しています。
- いずれも任意項目なので、他のキーではあえて未定義にしています。

#### EditorController.ts
- 機能2.の「ロード時にレーンを置き換える設定を追加」を実現するために処理を追加しました。
- 「order」の設定がセーブデータに書き出されることを防ぐため、最後にundefinedをセットしています。

#### ScoreData.ts
- 機能2.の「ロード時にレーンを置き換える設定を追加」を実現する際、「order」という項目を追加したためその内容を反映しています。任意項目にしています。
