### PR TITLE
feat: 譜面データ名のprefix設定を実装、データ復元条件の緩和

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -202,7 +202,7 @@ input[type="number"].editor-speed-piece::-webkit-inner-spin-button {
 }
 
 .option-sub-item-container {
-  margin: 2px auto 0 auto;
+  margin: 2px 1px 0 1px;
   width: 100px;
   float: left;
 }

--- a/docs/style.css
+++ b/docs/style.css
@@ -185,7 +185,7 @@ input[type="number"].editor-speed-piece::-webkit-inner-spin-button {
 #editor-option,
 #editor-save {
   position: absolute;
-  width: 300px;
+  width: 310px;
   height: 430px;
   top: 100px;
   background-color: rgba(245, 228, 159, 0.9);

--- a/docs/style.css
+++ b/docs/style.css
@@ -182,10 +182,9 @@ input[type="number"].editor-speed-piece::-webkit-inner-spin-button {
   text-decoration-line: none;
 }
 
-#editor-option,
-#editor-save {
+#editor-option, #editor-save {
   position: absolute;
-  width: 310px;
+  width: 320px;
   height: 430px;
   top: 100px;
   background-color: rgba(245, 228, 159, 0.9);
@@ -198,12 +197,18 @@ input[type="number"].editor-speed-piece::-webkit-inner-spin-button {
 
 .option-item-container {
   margin: 4px auto 0 auto;
-  width: 206px;
+  width: 220px;
 }
 
-.option-sub-item-container {
-  margin: 2px 1px 0 1px;
-  width: 100px;
+.option-sub-item-container-medium {
+  margin: 2px 5px 0 5px;
+  width: 130px;
+  float: left;
+}
+
+.option-sub-item-container-small {
+  margin: 2px 5px 0 5px;
+  width: 70px;
   float: left;
 }
 

--- a/docs/style.css
+++ b/docs/style.css
@@ -117,7 +117,7 @@ input[type="number"].editor-speed-piece::-webkit-inner-spin-button {
 }
 
 .uk-form-small {
-  height: 24px!important;
+  height: 24px !important;
 }
 
 #menu-output {
@@ -182,7 +182,8 @@ input[type="number"].editor-speed-piece::-webkit-inner-spin-button {
   text-decoration-line: none;
 }
 
-#editor-option, #editor-save {
+#editor-option,
+#editor-save {
   position: absolute;
   width: 300px;
   height: 430px;
@@ -197,7 +198,13 @@ input[type="number"].editor-speed-piece::-webkit-inner-spin-button {
 
 .option-item-container {
   margin: 4px auto 0 auto;
-  width: 106px;
+  width: 206px;
+}
+
+.option-sub-item-container {
+  margin: 2px auto 0 auto;
+  width: 100px;
+  float: left;
 }
 
 .save-item-container {
@@ -336,7 +343,7 @@ input[type="number"].editor-speed-piece::-webkit-inner-spin-button {
 
 .configure-context-title {
   margin: 5px auto;
-  color: salmon
+  color: salmon;
 }
 
 #configure-uploader {

--- a/public/style.css
+++ b/public/style.css
@@ -202,7 +202,7 @@ input[type="number"].editor-speed-piece::-webkit-inner-spin-button {
 }
 
 .option-sub-item-container {
-  margin: 2px auto 0 auto;
+  margin: 2px 1px 0 1px;
   width: 100px;
   float: left;
 }

--- a/public/style.css
+++ b/public/style.css
@@ -185,7 +185,7 @@ input[type="number"].editor-speed-piece::-webkit-inner-spin-button {
 #editor-option,
 #editor-save {
   position: absolute;
-  width: 300px;
+  width: 310px;
   height: 430px;
   top: 100px;
   background-color: rgba(245, 228, 159, 0.9);

--- a/public/style.css
+++ b/public/style.css
@@ -182,10 +182,9 @@ input[type="number"].editor-speed-piece::-webkit-inner-spin-button {
   text-decoration-line: none;
 }
 
-#editor-option,
-#editor-save {
+#editor-option, #editor-save {
   position: absolute;
-  width: 310px;
+  width: 320px;
   height: 430px;
   top: 100px;
   background-color: rgba(245, 228, 159, 0.9);
@@ -198,12 +197,18 @@ input[type="number"].editor-speed-piece::-webkit-inner-spin-button {
 
 .option-item-container {
   margin: 4px auto 0 auto;
-  width: 206px;
+  width: 220px;
 }
 
-.option-sub-item-container {
-  margin: 2px 1px 0 1px;
-  width: 100px;
+.option-sub-item-container-medium {
+  margin: 2px 5px 0 5px;
+  width: 130px;
+  float: left;
+}
+
+.option-sub-item-container-small {
+  margin: 2px 5px 0 5px;
+  width: 70px;
   float: left;
 }
 

--- a/public/style.css
+++ b/public/style.css
@@ -117,7 +117,7 @@ input[type="number"].editor-speed-piece::-webkit-inner-spin-button {
 }
 
 .uk-form-small {
-  height: 24px!important;
+  height: 24px !important;
 }
 
 #menu-output {
@@ -182,7 +182,8 @@ input[type="number"].editor-speed-piece::-webkit-inner-spin-button {
   text-decoration-line: none;
 }
 
-#editor-option, #editor-save {
+#editor-option,
+#editor-save {
   position: absolute;
   width: 300px;
   height: 430px;
@@ -197,7 +198,13 @@ input[type="number"].editor-speed-piece::-webkit-inner-spin-button {
 
 .option-item-container {
   margin: 4px auto 0 auto;
-  width: 106px;
+  width: 206px;
+}
+
+.option-sub-item-container {
+  margin: 2px auto 0 auto;
+  width: 100px;
+  float: left;
 }
 
 .save-item-container {
@@ -336,7 +343,7 @@ input[type="number"].editor-speed-piece::-webkit-inner-spin-button {
 
 .configure-context-title {
   margin: 5px auto;
-  color: salmon
+  color: salmon;
 }
 
 #configure-uploader {

--- a/src/components/editor/EditorController.vue
+++ b/src/components/editor/EditorController.vue
@@ -211,7 +211,7 @@ export default defineComponent({
       keyKind,
       keyConfig,
       scoreNumber: scoreData.scoreNumber ? scoreData.scoreNumber : 1,
-      scorePrefix: scoreData.scorePrefix || ``,
+      scorePrefix: scoreData.scorePrefix || "",
       pageBlockNum,
       musicUrl: this.loadMusicUrl || "",
       musicVolume: Number(localStorage.getItem("musicVolume")) || 1.0,

--- a/src/components/editor/EditorController.vue
+++ b/src/components/editor/EditorController.vue
@@ -9,6 +9,8 @@
       :timing="timing"
       :prop-score-number="scoreNumber"
       :prop-score-prefix="scorePrefix"
+      :prop-conv-key-kind="convKeyKind"
+      :prop-order="order"
       :music-volume="musicVolume"
       :music-rate="musicRate"
       @page-minus="pageMinus"
@@ -20,6 +22,8 @@
       v-model:musicVolume="musicVolume"
       v-model:musicRate="musicRate"
       v-model:scorePrefix="scorePrefix"
+      v-model:convKeyKind="convKeyKind"
+      v-model:order="order"
     ></editor-option>
     <editor-save :is-saving="isSaving" @save="save"></editor-save>
     <div id="editor-menu">
@@ -120,6 +124,8 @@ type DataType = {
   musicRate: number;
   isSaving: boolean;
   scoreConvertService: ScoreConvertService;
+  convKeyKind: string;
+  order: Array<number>;
 };
 
 export default defineComponent({
@@ -212,6 +218,8 @@ export default defineComponent({
       musicRate: 1.0,
       isSaving: false,
       scoreConvertService: new ScoreConvertService(keyKind, keyConfig, pageBlockNum),
+      convKeyKind: keyKind,
+      order: [],
     };
   },
   watch: {

--- a/src/components/editor/EditorController.vue
+++ b/src/components/editor/EditorController.vue
@@ -20,7 +20,6 @@
       v-model:musicVolume="musicVolume"
       v-model:musicRate="musicRate"
       v-model:scorePrefix="scorePrefix"
-      v-model:keyNum="keyNum"
     ></editor-option>
     <editor-save :is-saving="isSaving" @save="save"></editor-save>
     <div id="editor-menu">
@@ -113,7 +112,6 @@ type DataType = {
   scoreData: ScoreData;
   keyKind: CustomKeyKind;
   keyConfig: CustomKeyConfig;
-  keyNum: number;
   scoreNumber: number;
   scorePrefix: string;
   pageBlockNum: number;
@@ -206,7 +204,6 @@ export default defineComponent({
       scoreData,
       keyKind,
       keyConfig,
-      keyNum,
       scoreNumber: scoreData.scoreNumber ? scoreData.scoreNumber : 1,
       scorePrefix: scoreData.scorePrefix || "",
       pageBlockNum,

--- a/src/components/editor/EditorController.vue
+++ b/src/components/editor/EditorController.vue
@@ -24,6 +24,7 @@
       v-model:scorePrefix="scorePrefix"
       v-model:convKeyKind="convKeyKind"
       v-model:order="order"
+      v-model:keyNum="keyNum"
     ></editor-option>
     <editor-save :is-saving="isSaving" @save="save"></editor-save>
     <div id="editor-menu">
@@ -116,6 +117,7 @@ type DataType = {
   scoreData: ScoreData;
   keyKind: CustomKeyKind;
   keyConfig: CustomKeyConfig;
+  keyNum: number;
   scoreNumber: number;
   scorePrefix: string;
   pageBlockNum: number;
@@ -210,6 +212,7 @@ export default defineComponent({
       scoreData,
       keyKind,
       keyConfig,
+      keyNum,
       scoreNumber: scoreData.scoreNumber ? scoreData.scoreNumber : 1,
       scorePrefix: scoreData.scorePrefix || "",
       pageBlockNum,

--- a/src/components/editor/EditorController.vue
+++ b/src/components/editor/EditorController.vue
@@ -9,8 +9,6 @@
       :timing="timing"
       :prop-score-number="scoreNumber"
       :prop-score-prefix="scorePrefix"
-      :prop-conv-key-kind="convKeyKind"
-      :prop-order="order"
       :music-volume="musicVolume"
       :music-rate="musicRate"
       @page-minus="pageMinus"
@@ -22,8 +20,6 @@
       v-model:musicVolume="musicVolume"
       v-model:musicRate="musicRate"
       v-model:scorePrefix="scorePrefix"
-      v-model:convKeyKind="convKeyKind"
-      v-model:order="order"
       v-model:keyNum="keyNum"
     ></editor-option>
     <editor-save :is-saving="isSaving" @save="save"></editor-save>
@@ -126,8 +122,6 @@ type DataType = {
   musicRate: number;
   isSaving: boolean;
   scoreConvertService: ScoreConvertService;
-  convKeyKind: string;
-  order: Array<number>;
 };
 
 export default defineComponent({
@@ -221,8 +215,6 @@ export default defineComponent({
       musicRate: 1.0,
       isSaving: false,
       scoreConvertService: new ScoreConvertService(keyKind, keyConfig, pageBlockNum),
-      convKeyKind: keyKind,
-      order: [],
     };
   },
   watch: {

--- a/src/components/editor/EditorController.vue
+++ b/src/components/editor/EditorController.vue
@@ -8,6 +8,7 @@
       :key-kind="keyKind"
       :timing="timing"
       :prop-score-number="scoreNumber"
+      :prop-score-prefix="scorePrefix"
       :music-volume="musicVolume"
       :music-rate="musicRate"
       @page-minus="pageMinus"
@@ -18,6 +19,7 @@
       v-model:scoreNumber="scoreNumber"
       v-model:musicVolume="musicVolume"
       v-model:musicRate="musicRate"
+      v-model:scorePrefix="scorePrefix"
     ></editor-option>
     <editor-save :is-saving="isSaving" @save="save"></editor-save>
     <div id="editor-menu">
@@ -111,6 +113,7 @@ type DataType = {
   keyKind: CustomKeyKind;
   keyConfig: CustomKeyConfig;
   scoreNumber: number;
+  scorePrefix: string;
   pageBlockNum: number;
   musicUrl: string;
   musicVolume: number;
@@ -202,6 +205,7 @@ export default defineComponent({
       keyKind,
       keyConfig,
       scoreNumber: scoreData.scoreNumber ? scoreData.scoreNumber : 1,
+      scorePrefix: scoreData.scorePrefix || ``,
       pageBlockNum,
       musicUrl: this.loadMusicUrl || "",
       musicVolume: Number(localStorage.getItem("musicVolume")) || 1.0,
@@ -263,10 +267,8 @@ export default defineComponent({
     },
 
     convert(): void {
-      // NOTE: scoreNoを増やしたことによる暫定処置
-      const postfix = this.scoreData.scoreNumber !== 1 && this.scoreData.scoreNumber ? this.scoreData.scoreNumber.toString() : "";
       const converter = this.scoreConvertService;
-      const data: string = converter.convert(this.scoreData, postfix);
+      const data: string = converter.convert(this.scoreData);
       const message = "譜面データをクリップボードにコピーしました！";
       this.writeClipBoard(data, message);
 
@@ -314,10 +316,8 @@ export default defineComponent({
       return response.ok;
     },
     convertWithQuarters(): void {
-      // NOTE: scoreNoを増やしたことによる暫定処置
-      const postfix = this.scoreData.scoreNumber !== 1 && this.scoreData.scoreNumber ? this.scoreData.scoreNumber.toString() : "";
       const converter = this.scoreConvertService;
-      const data: string = converter.convertWithQuarters(this.scoreData, postfix);
+      const data: string = converter.convertWithQuarters(this.scoreData);
       const message = "四分譜面データをクリップボードにコピーしました！";
       this.writeClipBoard(data, message);
     },

--- a/src/components/editor/EditorMain.vue
+++ b/src/components/editor/EditorMain.vue
@@ -88,8 +88,6 @@ export default defineComponent({
     timing: { type: Object as PropType<Timing>, required: true },
     propScoreNumber: { type: Number, required: true },
     propScorePrefix: { type: String, required: true },
-    propConvKeyKind: { type: String, required: true },
-    propOrder: { type: Array<number>, required: true },
     musicVolume: { type: Number, required: true },
     musicRate: { type: Number, required: true },
   },
@@ -180,14 +178,6 @@ export default defineComponent({
 
     propScorePrefix(scorePrefix: string) {
       this.scoreData.scorePrefix = scorePrefix;
-    },
-
-    propConvKeyKind(convKeyKind: string) {
-      this.scoreData.keyKind = convKeyKind;
-    },
-
-    propOrder(order: number[]) {
-      this.scoreData.order = order.map(v => Number(v));
     },
 
     musicVolume(musicVolume: number) {

--- a/src/components/editor/EditorMain.vue
+++ b/src/components/editor/EditorMain.vue
@@ -88,6 +88,8 @@ export default defineComponent({
     timing: { type: Object as PropType<Timing>, required: true },
     propScoreNumber: { type: Number, required: true },
     propScorePrefix: { type: String, required: true },
+    propConvKeyKind: { type: String, required: true },
+    propOrder: { type: Array<number>, required: true },
     musicVolume: { type: Number, required: true },
     musicRate: { type: Number, required: true },
   },
@@ -178,6 +180,14 @@ export default defineComponent({
 
     propScorePrefix(scorePrefix: string) {
       this.scoreData.scorePrefix = scorePrefix;
+    },
+
+    propConvKeyKind(convKeyKind: string) {
+      this.scoreData.keyKind = convKeyKind;
+    },
+
+    propOrder(order: number[]) {
+      this.scoreData.order = order.map(v => Number(v));
     },
 
     musicVolume(musicVolume: number) {

--- a/src/components/editor/EditorMain.vue
+++ b/src/components/editor/EditorMain.vue
@@ -187,7 +187,7 @@ export default defineComponent({
     },
 
     propOrder(order: number[]) {
-      this.scoreData.order = order.map(v => Number(v)).slice(0, this.keyNum);
+      this.scoreData.order = order.map(v => Number(v));
     },
 
     musicVolume(musicVolume: number) {

--- a/src/components/editor/EditorMain.vue
+++ b/src/components/editor/EditorMain.vue
@@ -87,6 +87,7 @@ export default defineComponent({
     keyKind: { type: String as PropType<CustomKeyKind>, required: true },
     timing: { type: Object as PropType<Timing>, required: true },
     propScoreNumber: { type: Number, required: true },
+    propScorePrefix: { type: String, required: true },
     musicVolume: { type: Number, required: true },
     musicRate: { type: Number, required: true },
   },
@@ -173,6 +174,10 @@ export default defineComponent({
 
     propScoreNumber(scoreNumber: number) {
       this.scoreData.scoreNumber = scoreNumber;
+    },
+
+    propScorePrefix(scorePrefix: string) {
+      this.scoreData.scorePrefix = scorePrefix;
     },
 
     musicVolume(musicVolume: number) {

--- a/src/components/editor/EditorMain.vue
+++ b/src/components/editor/EditorMain.vue
@@ -187,7 +187,7 @@ export default defineComponent({
     },
 
     propOrder(order: number[]) {
-      this.scoreData.order = order.map(v => Number(v));
+      this.scoreData.order = order.map(v => Number(v)).slice(0, this.keyNum);
     },
 
     musicVolume(musicVolume: number) {

--- a/src/components/editor/EditorOption.vue
+++ b/src/components/editor/EditorOption.vue
@@ -21,7 +21,7 @@
       <div class="menu-txt">Music Speed</div>
       <input v-model.number="inputMusicRate" type="number" min="0.25" max="2" step="0.05" class="uk-input uk-form-small" />
     </div>
-    <div id="option-convert-key" class="option-item-container">
+    <div id="option-conv-key-kind" class="option-item-container">
       <div class="menu-txt">Conv.Keymode</div>
       <select id="option-key-selector" v-model="inputConvKeyKind" class="uk-select uk-form-width-medium uk-form-small">
         <option v-for="keyKind in keyKinds" :key="keyKind">

--- a/src/components/editor/EditorOption.vue
+++ b/src/components/editor/EditorOption.vue
@@ -2,13 +2,13 @@
   <div id="editor-option" class="uk-modal-dialog" uk-modal container="#editor-controller">
     <button class="uk-modal-close-default" type="button" uk-close></button>
 
-    <h2 class="uk-modal-title">Option</h2>
+    <h2 class="uk-modal-title">Options</h2>
     <div id="option-score-group" class="option-item-container">
-      <div id="option-score-number" class="option-sub-item-container">
+      <div id="option-score-number" class="option-sub-item-container-medium">
         <div class="menu-txt">Score No.</div>
         <input v-model.number="inputScoreNumber" type="number" min="1" class="uk-input uk-form-small" />
       </div>
-      <div id="option-score-prefix" class="option-sub-item-container">
+      <div id="option-score-prefix" class="option-sub-item-container-small">
         <div class="menu-txt">Prefix</div>
         <input v-model="inputScorePrefix" type="string" class="uk-input uk-form-small" />
       </div>
@@ -59,7 +59,14 @@ export default defineComponent({
     order: { type: Array<number>, required: true },
     keyNum: { type: Number, required: true },
   },
-  emits: ["update:scoreNumber", "update:musicVolume", "update:musicRate", "update:scorePrefix", "update:convKeyKind", "update:order"],
+  emits: [
+    "update:scoreNumber",
+    "update:musicVolume",
+    "update:musicRate",
+    "update:scorePrefix",
+    "update:convKeyKind",
+    "update:order",
+  ],
   computed: {
     keyKinds(): CustomKeyKind[] {
       const keyConfig = createCustomKeyConfig();
@@ -122,8 +129,13 @@ export default defineComponent({
         return this.order.join(`,`);
       },
       set(order: string) {
-        this.$emit("update:order", order.split(`,`)
-          .filter(v => !Number.isNaN(Number(v)) && !v.includes(".") && v.length <= 2).slice(0, this.keyNum));
+        this.$emit(
+          "update:order",
+          order
+            .split(`,`)
+            .filter((v) => !Number.isNaN(Number(v)) && !v.includes(".") && v.length <= 2)
+            .slice(0, this.keyNum)
+        );
       },
     },
   },

--- a/src/components/editor/EditorOption.vue
+++ b/src/components/editor/EditorOption.vue
@@ -116,7 +116,7 @@ export default defineComponent({
       },
       set(order: string) {
         this.$emit("update:order", order.split(`,`)
-          .filter(v => !Number.isNaN(Number(v)) && !v.includes(".") && Number(v) < 100).slice(0, this.keyNum));
+          .filter(v => !Number.isNaN(Number(v)) && !v.includes(".") && v.length <= 2).slice(0, this.keyNum));
       },
     },
   },

--- a/src/components/editor/EditorOption.vue
+++ b/src/components/editor/EditorOption.vue
@@ -50,6 +50,7 @@ export default defineComponent({
     scorePrefix: { type: String, required: true },
     convKeyKind: { type: String, required: true },
     order: { type: Array<number>, required: true },
+    keyNum: { type: Number, required: true },
   },
   emits: ["update:scoreNumber", "update:musicVolume", "update:musicRate", "update:scorePrefix", "update:convKeyKind", "update:order"],
   computed: {
@@ -114,7 +115,8 @@ export default defineComponent({
         return this.order.join(`,`);
       },
       set(order: string) {
-        this.$emit("update:order", order.split(`,`).filter(v => !Number.isNaN(Number(v))));
+        this.$emit("update:order", order.split(`,`)
+          .filter(v => !Number.isNaN(Number(v)) && !v.includes(".") && Number(v) < 100).slice(0, this.keyNum));
       },
     },
   },

--- a/src/components/editor/EditorOption.vue
+++ b/src/components/editor/EditorOption.vue
@@ -3,9 +3,15 @@
     <button class="uk-modal-close-default" type="button" uk-close></button>
 
     <h2 class="uk-modal-title">Option Settings</h2>
-    <div id="option-score-number" class="option-item-container">
-      <div class="menu-txt">Score No.</div>
-      <input v-model.number="inputScoreNumber" type="number" min="1" class="uk-input uk-form-small" />
+    <div id="option-score-group" class="option-item-container">
+      <div id="option-score-number" class="option-sub-item-container">
+        <div class="menu-txt">Score No.</div>
+        <input v-model.number="inputScoreNumber" type="number" min="1" class="uk-input uk-form-small" />
+      </div>
+      <div id="option-score-prefix" class="option-sub-item-container">
+        <div class="menu-txt">Prefix</div>
+        <input v-model="inputScorePrefix" type="string" class="uk-input uk-form-small" />
+      </div>
     </div>
     <div id="option-music-volume" class="option-item-container">
       <div class="menu-txt">Music Volume</div>
@@ -15,15 +21,26 @@
       <div class="menu-txt">Music Speed</div>
       <input v-model.number="inputMusicRate" type="number" min="0.25" max="2" step="0.05" class="uk-input uk-form-small" />
     </div>
-    <div id="option-score-prefix" class="option-item-container">
-      <div class="menu-txt">Score Prefix</div>
-      <input v-model="inputScorePrefix" type="string" class="uk-input uk-form-small" />
+    <div id="option-convert-key" class="option-item-container">
+      <div class="menu-txt">Conv.Keymode</div>
+      <select id="option-key-selector" v-model="inputConvKeyKind" class="uk-select uk-form-width-medium uk-form-small">
+        <option v-for="keyKind in keyKinds" :key="keyKind">
+          {{ keyKind }}
+        </option>
+      </select>
+    </div>
+    <div id="option-order" class="option-item-container">
+      <div class="menu-txt">Conv.Order</div>
+      <input v-model="inputOrder" type="string" class="uk-input uk-form-small" />
     </div>
   </div>
 </template>
 
 <script lang="ts">
+import { CustomKeyKind } from "@/model/KeyKind";
 import { defineComponent } from "vue";
+import { createCustomKeyConfig } from "../common/createCustomKeyConfig";
+
 export default defineComponent({
   name: "EditorOption",
   props: {
@@ -31,9 +48,18 @@ export default defineComponent({
     musicVolume: { type: Number, required: true },
     musicRate: { type: Number, required: true },
     scorePrefix: { type: String, required: true },
+    convKeyKind: { type: String, required: true },
+    order: { type: Array<number>, required: true },
   },
-  emits: ["update:scoreNumber", "update:musicVolume", "update:musicRate", "update:scorePrefix"],
+  emits: ["update:scoreNumber", "update:musicVolume", "update:musicRate", "update:scorePrefix", "update:convKeyKind", "update:order"],
   computed: {
+    keyKinds(): CustomKeyKind[] {
+      const keyConfig = createCustomKeyConfig();
+      const keys = Object.keys(keyConfig) as CustomKeyKind[];
+      keys.sort((a, b) => keyConfig[a].id - keyConfig[b].id);
+      return keys;
+    },
+
     inputScoreNumber: {
       get(): number {
         return this.scoreNumber;
@@ -71,6 +97,24 @@ export default defineComponent({
       },
       set(scorePrefix: string) {
         this.$emit("update:scorePrefix", scorePrefix);
+      },
+    },
+
+    inputConvKeyKind: {
+      get(): string {
+        return this.convKeyKind;
+      },
+      set(convKeyKind: string) {
+        this.$emit("update:convKeyKind", convKeyKind);
+      },
+    },
+
+    inputOrder: {
+      get(): string {
+        return this.order.join(`,`);
+      },
+      set(order: string) {
+        this.$emit("update:order", order.split(`,`));
       },
     },
   },

--- a/src/components/editor/EditorOption.vue
+++ b/src/components/editor/EditorOption.vue
@@ -19,11 +19,18 @@
     </div>
     <div id="option-music-rate" class="option-item-container">
       <div class="menu-txt">Music Speed</div>
-      <input v-model.number="inputMusicRate" type="number" min="0.25" max="2" step="0.05" class="uk-input uk-form-small" />
+      <input
+        v-model.number="inputMusicRate"
+        type="number"
+        min="0.25"
+        max="2"
+        step="0.05"
+        class="uk-input uk-form-width-small uk-form-small"
+      />
     </div>
     <div id="option-conv-key-kind" class="option-item-container">
       <div class="menu-txt">Conv.Keymode</div>
-      <select id="option-key-selector" v-model="inputConvKeyKind" class="uk-select uk-form-width-medium uk-form-small">
+      <select id="option-key-selector" v-model="inputConvKeyKind" class="uk-select uk-form-width-small uk-form-small">
         <option v-for="keyKind in keyKinds" :key="keyKind">
           {{ keyKind }}
         </option>

--- a/src/components/editor/EditorOption.vue
+++ b/src/components/editor/EditorOption.vue
@@ -15,6 +15,10 @@
       <div class="menu-txt">Music Speed</div>
       <input v-model.number="inputMusicRate" type="number" min="0.25" max="2" step="0.05" class="uk-input uk-form-small" />
     </div>
+    <div id="option-score-prefix" class="option-item-container">
+      <div class="menu-txt">Score Prefix</div>
+      <input v-model="inputScorePrefix" type="string" class="uk-input uk-form-small" />
+    </div>
   </div>
 </template>
 
@@ -26,8 +30,9 @@ export default defineComponent({
     scoreNumber: { type: Number, required: true },
     musicVolume: { type: Number, required: true },
     musicRate: { type: Number, required: true },
+    scorePrefix: { type: String, required: true },
   },
-  emits: ["update:scoreNumber", "update:musicVolume", "update:musicRate"],
+  emits: ["update:scoreNumber", "update:musicVolume", "update:musicRate", "update:scorePrefix"],
   computed: {
     inputScoreNumber: {
       get(): number {
@@ -57,6 +62,15 @@ export default defineComponent({
       set(musicRate: string) {
         const value = Number(musicRate);
         this.$emit("update:musicRate", value);
+      },
+    },
+
+    inputScorePrefix: {
+      get(): string {
+        return this.scorePrefix;
+      },
+      set(scorePrefix: string) {
+        this.$emit("update:scorePrefix", scorePrefix);
       },
     },
   },

--- a/src/components/editor/EditorOption.vue
+++ b/src/components/editor/EditorOption.vue
@@ -114,7 +114,7 @@ export default defineComponent({
         return this.order.join(`,`);
       },
       set(order: string) {
-        this.$emit("update:order", order.split(`,`));
+        this.$emit("update:order", order.split(`,`).filter(v => !Number.isNaN(Number(v))));
       },
     },
   },

--- a/src/components/editor/EditorOption.vue
+++ b/src/components/editor/EditorOption.vue
@@ -28,25 +28,11 @@
         class="uk-input uk-form-width-small uk-form-small"
       />
     </div>
-    <div id="option-conv-key-kind" class="option-item-container">
-      <div class="menu-txt">Conv.Keymode</div>
-      <select id="option-key-selector" v-model="inputConvKeyKind" class="uk-select uk-form-width-small uk-form-small">
-        <option v-for="keyKind in keyKinds" :key="keyKind">
-          {{ keyKind }}
-        </option>
-      </select>
-    </div>
-    <div id="option-order" class="option-item-container">
-      <div class="menu-txt">Conv.Order</div>
-      <input v-model="inputOrder" type="string" class="uk-input uk-form-small" />
-    </div>
   </div>
 </template>
 
 <script lang="ts">
-import { CustomKeyKind } from "@/model/KeyKind";
 import { defineComponent } from "vue";
-import { createCustomKeyConfig } from "../common/createCustomKeyConfig";
 
 export default defineComponent({
   name: "EditorOption",
@@ -55,26 +41,9 @@ export default defineComponent({
     musicVolume: { type: Number, required: true },
     musicRate: { type: Number, required: true },
     scorePrefix: { type: String, required: true },
-    convKeyKind: { type: String, required: true },
-    order: { type: Array<number>, required: true },
-    keyNum: { type: Number, required: true },
   },
-  emits: [
-    "update:scoreNumber",
-    "update:musicVolume",
-    "update:musicRate",
-    "update:scorePrefix",
-    "update:convKeyKind",
-    "update:order",
-  ],
+  emits: ["update:scoreNumber", "update:musicVolume", "update:musicRate", "update:scorePrefix"],
   computed: {
-    keyKinds(): CustomKeyKind[] {
-      const keyConfig = createCustomKeyConfig();
-      const keys = Object.keys(keyConfig) as CustomKeyKind[];
-      keys.sort((a, b) => keyConfig[a].id - keyConfig[b].id);
-      return keys;
-    },
-
     inputScoreNumber: {
       get(): number {
         return this.scoreNumber;
@@ -112,30 +81,6 @@ export default defineComponent({
       },
       set(scorePrefix: string) {
         this.$emit("update:scorePrefix", scorePrefix);
-      },
-    },
-
-    inputConvKeyKind: {
-      get(): string {
-        return this.convKeyKind;
-      },
-      set(convKeyKind: string) {
-        this.$emit("update:convKeyKind", convKeyKind);
-      },
-    },
-
-    inputOrder: {
-      get(): string {
-        return this.order.join(`,`);
-      },
-      set(order: string) {
-        this.$emit(
-          "update:order",
-          order
-            .split(`,`)
-            .filter((v) => !Number.isNaN(Number(v)) && !v.includes(".") && v.length <= 2)
-            .slice(0, this.keyNum)
-        );
       },
     },
   },

--- a/src/components/editor/EditorOption.vue
+++ b/src/components/editor/EditorOption.vue
@@ -2,7 +2,7 @@
   <div id="editor-option" class="uk-modal-dialog" uk-modal container="#editor-controller">
     <button class="uk-modal-close-default" type="button" uk-close></button>
 
-    <h2 class="uk-modal-title">Option Settings</h2>
+    <h2 class="uk-modal-title">Option</h2>
     <div id="option-score-group" class="option-item-container">
       <div id="option-score-number" class="option-sub-item-container">
         <div class="menu-txt">Score No.</div>

--- a/src/components/editor/service/ScoreConvertService.ts
+++ b/src/components/editor/service/ScoreConvertService.ts
@@ -92,7 +92,7 @@ export class ScoreConvertService {
     const startNumbers: number[] = scoreData.timings.map((timing) => timing.startNum);
     const bpms: number[] = scoreData.timings.map((timing) => timing.bpm);
     const scoreNumber = scoreData.scoreNumber || 1;
-    const scorePrefix = scoreData.scorePrefix || ``;
+    const scorePrefix = scoreData.scorePrefix || "";
 
     const easySave =
       `|es_keyKind=${keyKind}` +
@@ -109,7 +109,7 @@ export class ScoreConvertService {
   convert(scoreData: ScoreData): string {
     const frameScores = this.toFrameData(scoreData);
     const data = this.framesToOutputData(frameScores);
-    const prefix = scoreData.scorePrefix || ``;
+    const prefix = scoreData.scorePrefix || "";
     const postfix = scoreData.scoreNumber !== 1 && scoreData.scoreNumber ? scoreData.scoreNumber.toString() : "";
 
     data.speeds.sort((a, b) => a.position - b.position);

--- a/src/components/editor/service/ScoreConvertService.ts
+++ b/src/components/editor/service/ScoreConvertService.ts
@@ -92,6 +92,7 @@ export class ScoreConvertService {
     const startNumbers: number[] = scoreData.timings.map((timing) => timing.startNum);
     const bpms: number[] = scoreData.timings.map((timing) => timing.bpm);
     const scoreNumber = scoreData.scoreNumber || 1;
+    const scorePrefix = scoreData.scorePrefix || ``;
 
     const easySave =
       `|es_keyKind=${keyKind}` +
@@ -99,36 +100,39 @@ export class ScoreConvertService {
       `|es_label=${labels.join(",")}` +
       `|es_startNumber=${startNumbers.join(",")}` +
       `|es_bpm=${bpms.join(",")}` +
-      `|es_scoreNumber=${scoreNumber}|`;
+      `|es_scoreNumber=${scoreNumber}` +
+      `|es_scorePrefix=${scorePrefix}|`;
 
     return easySave;
   }
 
-  convert(scoreData: ScoreData, scorePostfix = ""): string {
+  convert(scoreData: ScoreData): string {
     const frameScores = this.toFrameData(scoreData);
     const data = this.framesToOutputData(frameScores);
+    const prefix = scoreData.scorePrefix || ``;
+    const postfix = scoreData.scoreNumber !== 1 && scoreData.scoreNumber ? scoreData.scoreNumber.toString() : "";
 
     data.speeds.sort((a, b) => a.position - b.position);
     data.boosts.sort((a, b) => a.position - b.position);
 
     const noteStr = data.notes
-      .reduce((str, notesArr, laneNum) => `${str}${this.keyConfig[this.keyKind].noteNames[laneNum]}=${notesArr.join(",")}|`, "|")
-      .replace(/_/g, `${scorePostfix}_`);
+      .reduce((str, notesArr, laneNum) => `${str}${prefix}${this.keyConfig[this.keyKind].noteNames[laneNum]}=${notesArr.join(",")}|`, "|")
+      .replace(/_/g, `${postfix}_`);
 
     const freezeStr = data.freezes
       .reduce(
-        (str, freezesArr, laneNum) => `${str}${this.keyConfig[this.keyKind].freezeNames[laneNum]}=${freezesArr.join(",")}|`,
+        (str, freezesArr, laneNum) => `${str}${prefix}${this.keyConfig[this.keyKind].freezeNames[laneNum]}=${freezesArr.join(",")}|`,
         ""
       )
-      .replace(/_/g, `${scorePostfix}_`);
+      .replace(/_/g, `${postfix}_`);
 
     const speedStr = ("speed_data=" + data.speeds.map((speed) => `${speed.position},${speed.value}`).join(",") + "|").replace(
       /_/g,
-      `${scorePostfix}_`
+      `${postfix}_`
     );
     const boostStr = ("boost_data=" + data.boosts.map((speed) => `${speed.position},${speed.value}`).join(",") + "|").replace(
       /_/g,
-      `${scorePostfix}_`
+      `${postfix}_`
     );
 
     const easySave = this.makeEasySave(scoreData);
@@ -153,7 +157,7 @@ ${easySave}
   }
 
   // 四分譜面の作成・変換
-  convertWithQuarters(scoreData: ScoreData, scorePostfix = ""): string {
+  convertWithQuarters(scoreData: ScoreData): string {
     const quarterNotes: number[] = [];
 
     // Todo: 四分譜面を出力するページ数を変更できるようにする
@@ -189,7 +193,7 @@ ${easySave}
       }
     }
 
-    return this.convert(this.cutLastDefault(newScoreData), scorePostfix);
+    return this.convert(this.cutLastDefault(newScoreData));
   }
 
   save(scoreData: ScoreData): string {

--- a/src/components/editor/service/ScoreRevivalService.ts
+++ b/src/components/editor/service/ScoreRevivalService.ts
@@ -8,7 +8,7 @@ import { Speed, SpeedType } from "@/model/Speed";
 import { PageScore } from "@/model/PageScore";
 
 export class ScoreRevivalService {
-  constructor(private keyConfig: CustomKeyConfig, private pageBlockNum: number) { }
+  constructor(private keyConfig: CustomKeyConfig, private pageBlockNum: number) {}
 
   private delimiter = "|";
 
@@ -25,12 +25,12 @@ export class ScoreRevivalService {
     try {
       const dict = this.fromOldCWToNewCW(rawDict);
       const keyKind: string = dict["keyKind"];
-      const blankFrame: number = parseInt(dict["blankFrame"]);
-      const labels: number[] = dict["label"].split(",").map((x: string) => parseInt(x));
-      const startNumbers: number[] = dict["startNumber"].split(",").map((x: string) => parseFloat(x));
-      const bpms: number[] = dict["bpm"].split(",").map((x: string) => parseFloat(x));
-      const scoreNumber: number = parseInt(dict["scoreNumber"]);
-      const scorePrefix: string = dict["scorePrefix"];
+      const blankFrame: number = parseInt(dict["blankFrame"]) || 200;
+      const labels: number[] = dict["label"]?.split(",").map((x: string) => parseInt(x)) ?? [1];
+      const startNumbers: number[] = dict["startNumber"]?.split(",").map((x: string) => parseFloat(x)) ?? [0];
+      const bpms: number[] = dict["bpm"]?.split(",").map((x: string) => parseFloat(x)) ?? [140];
+      const scoreNumber: number = parseInt(dict["scoreNumber"]) ?? 1;
+      const scorePrefix: string = dict["scorePrefix"] ?? "";
 
       const timings: Timing[] = labels.map((label, index) => ({
         label,
@@ -56,8 +56,8 @@ export class ScoreRevivalService {
     const scoreNumber = scoreData.scoreNumber as number;
     const scorePrefix = scoreData.scorePrefix as string;
 
-    const noteNames: string[] = this.keyConfig[keyKind].noteNames.map(v => `${scorePrefix}${v}`);
-    const freezeNames: string[] = this.keyConfig[keyKind].freezeNames.map(v => `${scorePrefix}${v}`);
+    const noteNames: string[] = this.keyConfig[keyKind].noteNames.map((v) => `${scorePrefix}${v}`);
+    const freezeNames: string[] = this.keyConfig[keyKind].freezeNames.map((v) => `${scorePrefix}${v}`);
     const speedChangeNames: string[] = "speed_data" in dict ? ["speed_data", "boost_data"] : ["speed_change", "boost_data"];
 
     const [noteFrames, freezeFrames, speedChangeFrames]: number[][][] = [noteNames, freezeNames, speedChangeNames].map((names) =>

--- a/src/components/editor/service/ScoreRevivalService.ts
+++ b/src/components/editor/service/ScoreRevivalService.ts
@@ -8,7 +8,7 @@ import { Speed, SpeedType } from "@/model/Speed";
 import { PageScore } from "@/model/PageScore";
 
 export class ScoreRevivalService {
-  constructor(private keyConfig: CustomKeyConfig, private pageBlockNum: number) {}
+  constructor(private keyConfig: CustomKeyConfig, private pageBlockNum: number) { }
 
   private delimiter = "|";
 
@@ -30,6 +30,7 @@ export class ScoreRevivalService {
       const startNumbers: number[] = dict["startNumber"].split(",").map((x: string) => parseFloat(x));
       const bpms: number[] = dict["bpm"].split(",").map((x: string) => parseFloat(x));
       const scoreNumber: number = parseInt(dict["scoreNumber"]);
+      const scorePrefix: string = dict["scorePrefix"];
 
       const timings: Timing[] = labels.map((label, index) => ({
         label,
@@ -41,6 +42,7 @@ export class ScoreRevivalService {
         blankFrame,
         timings,
         scoreNumber,
+        scorePrefix,
         scores: [],
       };
       return this.calcScoreData(dict, timings, scoreData);
@@ -52,9 +54,10 @@ export class ScoreRevivalService {
   private calcScoreData = (dict: { [name: string]: string }, timings: Timing[], scoreData: ScoreData) => {
     const keyKind = scoreData.keyKind as KeyKind;
     const scoreNumber = scoreData.scoreNumber as number;
+    const scorePrefix = scoreData.scorePrefix as string;
 
-    const noteNames: string[] = this.keyConfig[keyKind].noteNames;
-    const freezeNames: string[] = this.keyConfig[keyKind].freezeNames;
+    const noteNames: string[] = this.keyConfig[keyKind].noteNames.map(v => `${scorePrefix}${v}`);
+    const freezeNames: string[] = this.keyConfig[keyKind].freezeNames.map(v => `${scorePrefix}${v}`);
     const speedChangeNames: string[] = "speed_data" in dict ? ["speed_data", "boost_data"] : ["speed_change", "boost_data"];
 
     const [noteFrames, freezeFrames, speedChangeFrames]: number[][][] = [noteNames, freezeNames, speedChangeNames].map((names) =>

--- a/src/components/editor/service/ScoreRevivalService.ts
+++ b/src/components/editor/service/ScoreRevivalService.ts
@@ -29,7 +29,7 @@ export class ScoreRevivalService {
       const labels: number[] = dict["label"]?.split(",").map((x: string) => parseInt(x)) ?? [1];
       const startNumbers: number[] = dict["startNumber"]?.split(",").map((x: string) => parseFloat(x)) ?? [0];
       const bpms: number[] = dict["bpm"]?.split(",").map((x: string) => parseFloat(x)) ?? [140];
-      const scoreNumber: number = parseInt(dict["scoreNumber"]) ?? 1;
+      const scoreNumber: number = parseInt(dict["scoreNumber"]) || 1;
       const scorePrefix: string = dict["scorePrefix"] ?? "";
 
       const timings: Timing[] = labels.map((label, index) => ({

--- a/src/model/ScoreData.ts
+++ b/src/model/ScoreData.ts
@@ -9,6 +9,7 @@ export interface ScoreData {
   scoreNumber?: number;
   scores: PageScore[];
   order?: number[];
+  scorePrefix?: string;
 }
 
 export class DefaultScoreData implements ScoreData {
@@ -30,4 +31,5 @@ export class DefaultScoreData implements ScoreData {
   ];
 
   scoreNumber = 1;
+  scorePrefix = ``;
 }

--- a/src/model/ScoreData.ts
+++ b/src/model/ScoreData.ts
@@ -31,5 +31,5 @@ export class DefaultScoreData implements ScoreData {
   ];
 
   scoreNumber = 1;
-  scorePrefix = ``;
+  scorePrefix = "";
 }

--- a/src/test/components/editor/service/ScoreConvert.spec.ts
+++ b/src/test/components/editor/service/ScoreConvert.spec.ts
@@ -1,10 +1,10 @@
 import { ScoreConvertService, FrameData } from "@/components/editor/service/ScoreConvertService";
 import { KeyKind } from "@/model/KeyKind";
 import { KeyConfig, DefaultKeyConfig } from "@/model/KeyConfig";
-import { ScoreData, DefaultScoreData } from "@/model/ScoreData";
+import { ScoreData } from "@/model/ScoreData";
 import { cloneDeep } from "lodash";
 import { DefaultPageScore } from "@/model/PageScore";
-import { test2DosData, test2ScoreData, testDosData, testScoreData } from "./testScoreData";
+import { testDos, testScore } from "./testScoreData";
 
 import "mock-local-storage";
 
@@ -14,7 +14,7 @@ describe("scoreConvertService", () => {
   const keyNum: number = keyConfig[keyKind].num;
   const pageBlockNum = 8;
   const scoreConverter = new ScoreConvertService(keyKind, keyConfig, pageBlockNum);
-  const scoreData: ScoreData = testScoreData;
+  const scoreData: ScoreData = testScore.score5_1;
 
   it("frameDataへの変換が正しく出来る", () => {
     const expectedFrameData: FrameData[] = [
@@ -42,11 +42,15 @@ describe("scoreConvertService", () => {
   });
 
   it("dosの出力が正しく出来る", () => {
-    expect(scoreConverter.convert(scoreData)).toBe(testDosData);
+    expect(scoreConverter.convert(testScore.score5_1)).toBe(testDos.dos5_1);
   });
 
   it("2譜面目でも正しく出力出来る", () => {
-    expect(scoreConverter.convert(test2ScoreData)).toBe(test2DosData);
+    expect(scoreConverter.convert(testScore.score5_2)).toBe(testDos.dos5_2);
+  });
+
+  it("prefixが正しく出力出来る", () => {
+    expect(scoreConverter.convert(testScore.score5_1Prefix)).toBe(testDos.dos5_1Prefix);
   });
 
   it("譜面データの後ろの空白が削除されている", () => {
@@ -56,12 +60,6 @@ describe("scoreConvertService", () => {
   });
 
   it("四分譜面が生成されている", () => {
-    const initialScoreData: ScoreData = new DefaultScoreData(keyNum);
-    initialScoreData.keyKind = "5";
-    const expectedData = `|left_data=200,226,251,277,303,329,354,380,406,431,457,483,509,534,560,586,611,637,663,689,714,740,766,791,817,843,869,894,920,946,971,997,1023,1049,1074,1100,1126,1151,1177,1203,1229,1254,1280,1306,1331,1357,1383,1409,1434,1460,1486,1511,1537,1563,1589,1614,1640,1666,1691,1717,1743,1769,1794,1820,1846,1871,1897,1923,1949,1974,2000,2026,2051,2077,2103,2129,2154,2180,2206,2231,2257,2283,2309,2334,2360,2386,2411,2437,2463,2489,2514,2540,2566,2591,2617,2643,2669,2694,2720,2746,2771,2797,2823,2849,2874,2900,2926,2951,2977,3003,3029,3054,3080,3106,3131,3157,3183,3209,3234,3260,3286,3311,3337,3363,3389,3414,3440,3466,3491,3517,3543,3569,3594,3620,3646,3671,3697,3723,3749,3774,3800,3826,3851,3877,3903,3929,3954,3980,4006,4031,4057,4083,4109,4134,4160,4186,4211,4237,4263,4289|down_data=|up_data=|right_data=|space_data=|frzLeft_data=|frzDown_data=|frzUp_data=|frzRight_data=|frzSpace_data=|
-|speed_data=|boost_data=|
-|es_keyKind=5|es_blankFrame=200|es_label=1|es_startNumber=0|es_bpm=140|es_scoreNumber=1|
-`;
-    expect(scoreConverter.convertWithQuarters(initialScoreData)).toBe(expectedData);
+    expect(scoreConverter.convertWithQuarters(testScore.score5_1Initial)).toBe(testDos.dos5_1Initial);
   });
 });

--- a/src/test/components/editor/service/ScoreConvert.spec.ts
+++ b/src/test/components/editor/service/ScoreConvert.spec.ts
@@ -46,7 +46,7 @@ describe("scoreConvertService", () => {
   });
 
   it("2譜面目でも正しく出力出来る", () => {
-    expect(scoreConverter.convert(test2ScoreData, "2")).toBe(test2DosData);
+    expect(scoreConverter.convert(test2ScoreData)).toBe(test2DosData);
   });
 
   it("譜面データの後ろの空白が削除されている", () => {

--- a/src/test/components/editor/service/ScoreRevivalService.spec.ts
+++ b/src/test/components/editor/service/ScoreRevivalService.spec.ts
@@ -1,6 +1,6 @@
 import { ScoreRevivalService } from "@/components/editor/service/ScoreRevivalService";
 import { DefaultKeyConfig } from "@/model/KeyConfig";
-import { test2DosData, test2ScoreData, testDosData, testScoreData } from "./testScoreData";
+import { testDos, testScore } from "./testScoreData";
 
 describe("dosConvert", () => {
   it("正しくscoreDataに変換できる", () => {
@@ -8,8 +8,8 @@ describe("dosConvert", () => {
     const pageBlockNum = 8;
     const scoreRevivalService = new ScoreRevivalService(keyConfig, pageBlockNum);
 
-    const scoreData = scoreRevivalService.dosConvert(testDosData);
-    expect(scoreData).toStrictEqual(testScoreData);
+    const scoreData = scoreRevivalService.dosConvert(testDos.dos5_1);
+    expect(scoreData).toStrictEqual(testScore.score5_1);
   });
 
   it("2譜面目でも正しくscoreDataに変換できる", () => {
@@ -17,8 +17,35 @@ describe("dosConvert", () => {
     const pageBlockNum = 8;
     const scoreRevivalService = new ScoreRevivalService(keyConfig, pageBlockNum);
 
-    const scoreData = scoreRevivalService.dosConvert(test2DosData);
-    expect(scoreData).toStrictEqual(test2ScoreData);
+    const scoreData = scoreRevivalService.dosConvert(testDos.dos5_2);
+    expect(scoreData).toStrictEqual(testScore.score5_2);
+  });
+
+  it("2譜面目でも正しくscoreDataに変換できる(v3.3.0以前互換)", () => {
+    const keyConfig = DefaultKeyConfig;
+    const pageBlockNum = 8;
+    const scoreRevivalService = new ScoreRevivalService(keyConfig, pageBlockNum);
+
+    const scoreData = scoreRevivalService.dosConvert(testDos.dos5_2Abb);
+    expect(scoreData).toStrictEqual(testScore.score5_2);
+  });
+
+  it("prefixがついた譜面でも正しくscoreDataに変換できる", () => {
+    const keyConfig = DefaultKeyConfig;
+    const pageBlockNum = 8;
+    const scoreRevivalService = new ScoreRevivalService(keyConfig, pageBlockNum);
+
+    const scoreData = scoreRevivalService.dosConvert(testDos.dos5_1Prefix);
+    expect(scoreData).toStrictEqual(testScore.score5_1Prefix);
+  });
+
+  it("prefixがついた譜面でblankFrameやscoreNumberが欠けていても正しくscoreDataに変換できる", () => {
+    const keyConfig = DefaultKeyConfig;
+    const pageBlockNum = 8;
+    const scoreRevivalService = new ScoreRevivalService(keyConfig, pageBlockNum);
+
+    const scoreData = scoreRevivalService.dosConvert(testDos.dos5_1PrefixAbb);
+    expect(scoreData).toStrictEqual(testScore.score5_1Prefix);
   });
 
   it("不正なデータならnullが返る", () => {

--- a/src/test/components/editor/service/ScoreRevivalService.spec.ts
+++ b/src/test/components/editor/service/ScoreRevivalService.spec.ts
@@ -3,56 +3,36 @@ import { DefaultKeyConfig } from "@/model/KeyConfig";
 import { testDos, testScore } from "./testScoreData";
 
 describe("dosConvert", () => {
-  it("正しくscoreDataに変換できる", () => {
-    const keyConfig = DefaultKeyConfig;
-    const pageBlockNum = 8;
-    const scoreRevivalService = new ScoreRevivalService(keyConfig, pageBlockNum);
+  const keyConfig = DefaultKeyConfig;
+  const pageBlockNum = 8;
+  const scoreRevivalService = new ScoreRevivalService(keyConfig, pageBlockNum);
 
+  it("正しくscoreDataに変換できる", () => {
     const scoreData = scoreRevivalService.dosConvert(testDos.dos5_1);
     expect(scoreData).toStrictEqual(testScore.score5_1);
   });
 
   it("2譜面目でも正しくscoreDataに変換できる", () => {
-    const keyConfig = DefaultKeyConfig;
-    const pageBlockNum = 8;
-    const scoreRevivalService = new ScoreRevivalService(keyConfig, pageBlockNum);
-
     const scoreData = scoreRevivalService.dosConvert(testDos.dos5_2);
     expect(scoreData).toStrictEqual(testScore.score5_2);
   });
 
   it("2譜面目でも正しくscoreDataに変換できる(v3.3.0以前互換)", () => {
-    const keyConfig = DefaultKeyConfig;
-    const pageBlockNum = 8;
-    const scoreRevivalService = new ScoreRevivalService(keyConfig, pageBlockNum);
-
     const scoreData = scoreRevivalService.dosConvert(testDos.dos5_2Abb);
     expect(scoreData).toStrictEqual(testScore.score5_2);
   });
 
   it("prefixがついた譜面でも正しくscoreDataに変換できる", () => {
-    const keyConfig = DefaultKeyConfig;
-    const pageBlockNum = 8;
-    const scoreRevivalService = new ScoreRevivalService(keyConfig, pageBlockNum);
-
     const scoreData = scoreRevivalService.dosConvert(testDos.dos5_1Prefix);
     expect(scoreData).toStrictEqual(testScore.score5_1Prefix);
   });
 
   it("prefixがついた譜面でblankFrameやscoreNumberが欠けていても正しくscoreDataに変換できる", () => {
-    const keyConfig = DefaultKeyConfig;
-    const pageBlockNum = 8;
-    const scoreRevivalService = new ScoreRevivalService(keyConfig, pageBlockNum);
-
     const scoreData = scoreRevivalService.dosConvert(testDos.dos5_1PrefixAbb);
     expect(scoreData).toStrictEqual(testScore.score5_1Prefix);
   });
 
   it("不正なデータならnullが返る", () => {
-    const keyConfig = DefaultKeyConfig;
-    const pageBlockNum = 8;
-    const scoreRevivalService = new ScoreRevivalService(keyConfig, pageBlockNum);
-
     const scoreData = scoreRevivalService.dosConvert("|aaa|bbb|");
     expect(scoreData).toBe(null);
   });

--- a/src/test/components/editor/service/testScoreData.ts
+++ b/src/test/components/editor/service/testScoreData.ts
@@ -84,7 +84,7 @@ export const testDos = {
   // 2譜面目: 復元確認データ（復元データ欠けあり）
   dos5_2Abb: `|left2_data=200|down2_data=360,380|up2_data=240,400|right2_data=|space2_data=440,500|frzLeft2_data=|frzDown2_data=|frzUp2_data=|frzRight2_data=280,360|frzSpace2_data=|
 |speed2_data=360,1.1,440,0.7|boost2_data=400,0.8|
-|es_keyKind=5|es_blankFrame=200|es_label=1,3|es_startNumber=0,240|es_bpm=180,120|es_scoreNumber=2|es_scorePrefix=|
+|es_keyKind=5|es_blankFrame=200|es_label=1,3|es_startNumber=0,240|es_bpm=180,120|es_scoreNumber=2|
 `,
 
   // 1譜面目: 出力確認（兼復元）データ、prefixあり

--- a/src/test/components/editor/service/testScoreData.ts
+++ b/src/test/components/editor/service/testScoreData.ts
@@ -1,4 +1,4 @@
-import { ScoreData } from "@/model/ScoreData";
+import { DefaultScoreData, ScoreData } from "@/model/ScoreData";
 import { cloneDeep } from "lodash";
 
 export const testScoreData: ScoreData = {
@@ -17,6 +17,7 @@ export const testScoreData: ScoreData = {
     },
   ],
   scoreNumber: 1,
+  scorePrefix: "",
   scores: [
     {
       notes: [[0], [], [96], [], []],
@@ -39,18 +40,68 @@ export const testScoreData: ScoreData = {
   ],
 };
 
-export const test2ScoreData: ScoreData = (() => {
-  const scoreData = cloneDeep(testScoreData);
-  scoreData.scoreNumber = 2;
-  return scoreData;
-})();
+// 基礎となるセーブデータを元にパラメータを与えてアレンジ
+const changeScoreData =
+  (baseScoreData: ScoreData = testScoreData) =>
+  ({ scoreNumber = 1 as number, scorePrefix = "" as string, keyKind = baseScoreData.keyKind as string } = {}) => {
+    const scoreData = cloneDeep(baseScoreData);
+    scoreData.scoreNumber = scoreNumber;
+    scoreData.scorePrefix = scorePrefix;
+    scoreData.keyKind = keyKind;
+    return scoreData;
+  };
 
-export const testDosData = `|left_data=200|down_data=360,380|up_data=240,400|right_data=|space_data=440,500|frzLeft_data=|frzDown_data=|frzUp_data=|frzRight_data=280,360|frzSpace_data=|
+// 基礎となるセーブデータ群
+const scorePtn = {
+  key5: changeScoreData(),
+  default5: changeScoreData(new DefaultScoreData(5)),
+  //key11: changeScoreData(testScoreData11),
+};
+
+// セーブデータのテストパターン
+export const testScore = {
+  score5_1: scorePtn.key5(),
+  score5_1Initial: scorePtn.default5({ keyKind: "5" }),
+  score5_2: scorePtn.key5({ scoreNumber: 2 }),
+  score5_1Prefix: scorePtn.key5({ scorePrefix: "a" }),
+  //score11_1: scorePtn.key11(),
+};
+
+// 譜面データのテストパターン群
+export const testDos = {
+  // 1譜面目: 出力確認（兼復元）データ
+  dos5_1: `|left_data=200|down_data=360,380|up_data=240,400|right_data=|space_data=440,500|frzLeft_data=|frzDown_data=|frzUp_data=|frzRight_data=280,360|frzSpace_data=|
 |speed_data=360,1.1,440,0.7|boost_data=400,0.8|
-|es_keyKind=5|es_blankFrame=200|es_label=1,3|es_startNumber=0,240|es_bpm=180,120|es_scoreNumber=1|
-`;
+|es_keyKind=5|es_blankFrame=200|es_label=1,3|es_startNumber=0,240|es_bpm=180,120|es_scoreNumber=1|es_scorePrefix=|
+`,
 
-export const test2DosData = `|left2_data=200|down2_data=360,380|up2_data=240,400|right2_data=|space2_data=440,500|frzLeft2_data=|frzDown2_data=|frzUp2_data=|frzRight2_data=280,360|frzSpace2_data=|
+  // 2譜面目: 出力確認（兼復元）データ
+  dos5_2: `|left2_data=200|down2_data=360,380|up2_data=240,400|right2_data=|space2_data=440,500|frzLeft2_data=|frzDown2_data=|frzUp2_data=|frzRight2_data=280,360|frzSpace2_data=|
 |speed2_data=360,1.1,440,0.7|boost2_data=400,0.8|
-|es_keyKind=5|es_blankFrame=200|es_label=1,3|es_startNumber=0,240|es_bpm=180,120|es_scoreNumber=2|
-`;
+|es_keyKind=5|es_blankFrame=200|es_label=1,3|es_startNumber=0,240|es_bpm=180,120|es_scoreNumber=2|es_scorePrefix=|
+`,
+
+  // 2譜面目: 復元確認データ（復元データ欠けあり）
+  dos5_2Abb: `|left2_data=200|down2_data=360,380|up2_data=240,400|right2_data=|space2_data=440,500|frzLeft2_data=|frzDown2_data=|frzUp2_data=|frzRight2_data=280,360|frzSpace2_data=|
+|speed2_data=360,1.1,440,0.7|boost2_data=400,0.8|
+|es_keyKind=5|es_blankFrame=200|es_label=1,3|es_startNumber=0,240|es_bpm=180,120|es_scoreNumber=2|es_scorePrefix=|
+`,
+
+  // 1譜面目: 出力確認（兼復元）データ、prefixあり
+  dos5_1Prefix: `|aleft_data=200|adown_data=360,380|aup_data=240,400|aright_data=|aspace_data=440,500|afrzLeft_data=|afrzDown_data=|afrzUp_data=|afrzRight_data=280,360|afrzSpace_data=|
+|speed_data=360,1.1,440,0.7|boost_data=400,0.8|
+|es_keyKind=5|es_blankFrame=200|es_label=1,3|es_startNumber=0,240|es_bpm=180,120|es_scoreNumber=1|es_scorePrefix=a|
+`,
+
+  // 1譜面目: 復元確認データ（復元データ欠けあり）、prefixあり
+  dos5_1PrefixAbb: `|aleft_data=200|adown_data=360,380|aup_data=240,400|aright_data=|aspace_data=440,500|afrzLeft_data=|afrzDown_data=|afrzUp_data=|afrzRight_data=280,360|afrzSpace_data=|
+|speed_data=360,1.1,440,0.7|boost_data=400,0.8|
+|es_keyKind=5|es_label=1,3|es_startNumber=0,240|es_bpm=180,120|es_scorePrefix=a|
+`,
+
+  // 1譜面目: 4分譜面出力データ
+  dos5_1Initial: `|left_data=200,226,251,277,303,329,354,380,406,431,457,483,509,534,560,586,611,637,663,689,714,740,766,791,817,843,869,894,920,946,971,997,1023,1049,1074,1100,1126,1151,1177,1203,1229,1254,1280,1306,1331,1357,1383,1409,1434,1460,1486,1511,1537,1563,1589,1614,1640,1666,1691,1717,1743,1769,1794,1820,1846,1871,1897,1923,1949,1974,2000,2026,2051,2077,2103,2129,2154,2180,2206,2231,2257,2283,2309,2334,2360,2386,2411,2437,2463,2489,2514,2540,2566,2591,2617,2643,2669,2694,2720,2746,2771,2797,2823,2849,2874,2900,2926,2951,2977,3003,3029,3054,3080,3106,3131,3157,3183,3209,3234,3260,3286,3311,3337,3363,3389,3414,3440,3466,3491,3517,3543,3569,3594,3620,3646,3671,3697,3723,3749,3774,3800,3826,3851,3877,3903,3929,3954,3980,4006,4031,4057,4083,4109,4134,4160,4186,4211,4237,4263,4289|down_data=|up_data=|right_data=|space_data=|frzLeft_data=|frzDown_data=|frzUp_data=|frzRight_data=|frzSpace_data=|
+|speed_data=|boost_data=|
+|es_keyKind=5|es_blankFrame=200|es_label=1|es_startNumber=0|es_bpm=140|es_scoreNumber=1|es_scorePrefix=|
+`,
+};

--- a/src/test/components/editor/service/testScoreData.ts
+++ b/src/test/components/editor/service/testScoreData.ts
@@ -42,7 +42,7 @@ export const testScoreData: ScoreData = {
 
 // 基礎となるセーブデータを元にパラメータを与えてアレンジ
 const changeScoreData =
-  (baseScoreData: ScoreData = testScoreData) =>
+  ({ keyNum = 5 as number, baseScoreData = new DefaultScoreData(keyNum) as ScoreData } = {}) =>
   ({ scoreNumber = 1 as number, scorePrefix = "" as string, keyKind = baseScoreData.keyKind as string } = {}) => {
     const scoreData = cloneDeep(baseScoreData);
     scoreData.scoreNumber = scoreNumber;
@@ -53,9 +53,10 @@ const changeScoreData =
 
 // 基礎となるセーブデータ群
 const scorePtn = {
-  key5: changeScoreData(),
-  default5: changeScoreData(new DefaultScoreData(5)),
-  //key11: changeScoreData(testScoreData11),
+  default5: changeScoreData(),
+  key5: changeScoreData({ baseScoreData: testScoreData }),
+  //default11: changeScoreData({ keyNum: 11 }),
+  //key11: changeScoreData({ baseScoreData: testScoreData11 }),
 };
 
 // セーブデータのテストパターン


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

>### 1. order設定をオプションから操作できるよう変更
><s>- PR #113 で実装したセーブ変数 "order" をオプションから操作・出力できるようにしました。
>- 変換先のキー名と、順序（カンマ区切り）をそれぞれ「Conv.Keymode」「Conv.Order」にて設定します。
>- 「Conv.Order」には数字（0～99）とカンマ文字以外が入らないよう制御し、
>現在制作中のキーのレーン数を超えた定義はできないように制御しています。（割り当てできないため）
>- 一度ロードすると「Conv.Order」の中身がリセットされる仕組みは同じです。</s>

⇒この機能の実装は取り止め

### 2. 譜面データ名のprefix設定を追加
- 「left_data」「frzLeft_data」などの譜面データ名の前に任意の文字列を先頭に付加する機能を
オプションに追加しました。Prefixに「a」を設定すると「aleft_data」「afrzLeft_data」のようになります。
- セーブデータの出力の他、復元データにも対応しています。`es_scorePrefix`として定義。

### 3. オプション画面の横幅を調整し、2列配置ができるように変更
- 1, 2のオプション追加や今後を見越して、2列に配置できるようにCSSを変更しました。
- タイトルを「Option Settings」->「Options」にしました。

### 4. 譜面からの復元データについて、es_keyKind以外のフッターを任意化
- 指定が無かった場合、デフォルト値を採用するように変更しました。

|変数名|デフォルト値|
|----|----|
|es_blankFrame|200|
|es_label|1|
|es_startNumber|0|
|es_bpm|140|
|es_scoreNumber|1|
|es_scorePrefix|(なし)|

### 5. その他
- ScoreConvertService.convert, convertWithQuartersの引数を1つに戻しました。
  - 譜面番号 (scoreNumber)が引数にいましたが、scoreDataに含まれているので関数内に内包しました。
  - 対応するテスト関数も引数が1つになるように修正しています。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
>1. <s>PR #113 で仮実装したが、画面から行えた方が便利であるため。</s>
2. トランスキーなどの特殊キーで、従来のエディターキー定義を使いまわそうとしても
譜面データ名の重複が原因でエディター定義を作り直すことが多いため。
3. 今の状態でオプション項目をそのまま追加すると縦スクロールが発生してしまうため。
4. 譜面復元のハードルを下げるため。
ただし、scoreNumber/scorePrefixが必須になる譜面については
指定が無いとエラーは出ませんが読み込んでも空になります。（意図通りの動き）
5. 2.の実装と類似した内容のため、実装方法を合わせました。

## :camera: スクリーンショット / Screenshot
<img src="https://github.com/user-attachments/assets/86b44d36-f973-4003-a49e-1a182359974f" width="30%"><img src="https://github.com/user-attachments/assets/2e9da816-6ec6-4525-bbaa-a9c781803b95" width="30%">

<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

## :pencil: その他コメント / Other Comments
### 内部的な仕様変化点
### style.css
- オプション画面の2列表示対応のため、以下を対応しました。
  - option-sub-item-container-medium, option-sub-item-container-smallを追加
  - option-item-container の幅を 106px ⇒ 220px に変更
  - #editor-option, #editor-save の幅を 300px ⇒ 320px に変更

<img src="https://github.com/user-attachments/assets/41c08d08-25d8-4da3-879f-d0836be23638" width="50%">

### EditorController.vue
- 他画面との値受け渡しのため、変数を追加しました。
  - (EditorMain) scorePrefix, <s>convKeyKind, order</s>
  - (EditorOption) scorePrefix, <s>convKeyKind, order, keyNum　※keyNumはorder項目の指定数チェック用</s>

>### EditorMain.vue
>- order項目の変換処理に関連する値の受け渡し処理を追加しました。
>（変換処理自体は前のPRで実装済み）

### EditorOption.vue
- scorePrefix, <s>convKeyKind, orderの3</s>項目を画面に追加しました。
- <s>order項目については数字（0～99）とカンマ文字以外が入らないように＆項目数が作成中のキー数のレーン数を超えないように制御しています。</s>

### ScoreConvertService.ts
- scorePrefixの処理を追加しました。また、scoreNumberの処理をEditorController.vueから移動しました。

### ScoreRevivalService.ts
- scorePrefixの処理を追加しました。また、他項目（keyKind以外）について初期値を与えるように変更しました。

### ScoreData.ts
- scorePrefixを追加しています。

テスト用ファイルの変化点については下記コメントから
https://github.com/superkuppabros/danoni-editor/pull/115#issuecomment-2253676097

### コメント
- できるだけ現在の実装方法に沿った形で作っているつもりですが、まずい点などあればご指摘お願いします。

<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
