### PR TITLE
feat: クリック・タップモードの導入

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -139,6 +139,11 @@ input[type="number"].editor-speed-piece::-webkit-inner-spin-button {
   transition: 0.4s;
 }
 
+.btn-controller {
+  font-size: 14px;
+  height: 20px;
+}
+
 .btn-blue {
   color: #67c5ff;
   border: solid 2px #67c5ff;
@@ -157,6 +162,12 @@ input[type="number"].editor-speed-piece::-webkit-inner-spin-button {
 .btn-orange {
   color: #ff9c4a;
   border: solid 2px #ff9c4a;
+  width: 100px;
+}
+
+.btn-purple {
+  color: #9944ff;
+  border: solid 2px #9944ff;
   width: 100px;
 }
 
@@ -179,6 +190,11 @@ input[type="number"].editor-speed-piece::-webkit-inner-spin-button {
 
 .btn-orange:hover {
   background: #ff9c4a;
+  text-decoration-line: none;
+}
+
+.btn-purple:hover {
+  background: #9944ff;
   text-decoration-line: none;
 }
 

--- a/docs/style.css
+++ b/docs/style.css
@@ -144,6 +144,10 @@ input[type="number"].editor-speed-piece::-webkit-inner-spin-button {
   height: 20px;
 }
 
+.btn-mini {
+  width: 18px;
+}
+
 .btn-blue {
   color: #67c5ff;
   border: solid 2px #67c5ff;

--- a/docs/style.css
+++ b/docs/style.css
@@ -340,7 +340,7 @@ input[type="number"].editor-speed-piece::-webkit-inner-spin-button {
 /* 設定画面 */
 #configure-container {
   width: 500px;
-  height: 475px;
+  height: 500px;
   margin: auto;
   background-color: rgb(255, 221, 127);
   font-family: "Segoe UI", "Yu Gothic", sans-serif;

--- a/docs/style.css
+++ b/docs/style.css
@@ -24,6 +24,16 @@ container {
   top: 5px;
   left: 50px;
   font-size: 11px;
+  text-align: left;
+  white-space: nowrap;
+}
+
+#editor-mode-input {
+  position: absolute;
+  top: 5px;
+  left: calc(100%);
+  font-size: 11px;
+  text-align: left;
   white-space: nowrap;
 }
 
@@ -382,7 +392,7 @@ input[type="number"].editor-speed-piece::-webkit-inner-spin-button {
   justify-content: left;
   font-size: 16px;
   padding: 0 40px;
-  margin: 10px 0;
+  margin: 5px 0;
 }
 
 .configure-options {

--- a/docs/style.css
+++ b/docs/style.css
@@ -168,7 +168,6 @@ input[type="number"].editor-speed-piece::-webkit-inner-spin-button {
 .btn-purple {
   color: #9944ff;
   border: solid 2px #9944ff;
-  width: 100px;
 }
 
 .menu-output-btn:hover {

--- a/public/style.css
+++ b/public/style.css
@@ -139,6 +139,11 @@ input[type="number"].editor-speed-piece::-webkit-inner-spin-button {
   transition: 0.4s;
 }
 
+.btn-controller {
+  font-size: 14px;
+  height: 20px;
+}
+
 .btn-blue {
   color: #67c5ff;
   border: solid 2px #67c5ff;
@@ -157,6 +162,12 @@ input[type="number"].editor-speed-piece::-webkit-inner-spin-button {
 .btn-orange {
   color: #ff9c4a;
   border: solid 2px #ff9c4a;
+  width: 100px;
+}
+
+.btn-purple {
+  color: #9944ff;
+  border: solid 2px #9944ff;
   width: 100px;
 }
 
@@ -179,6 +190,11 @@ input[type="number"].editor-speed-piece::-webkit-inner-spin-button {
 
 .btn-orange:hover {
   background: #ff9c4a;
+  text-decoration-line: none;
+}
+
+.btn-purple:hover {
+  background: #9944ff;
   text-decoration-line: none;
 }
 

--- a/public/style.css
+++ b/public/style.css
@@ -144,6 +144,10 @@ input[type="number"].editor-speed-piece::-webkit-inner-spin-button {
   height: 20px;
 }
 
+.btn-mini {
+  width: 18px;
+}
+
 .btn-blue {
   color: #67c5ff;
   border: solid 2px #67c5ff;

--- a/public/style.css
+++ b/public/style.css
@@ -340,7 +340,7 @@ input[type="number"].editor-speed-piece::-webkit-inner-spin-button {
 /* 設定画面 */
 #configure-container {
   width: 500px;
-  height: 475px;
+  height: 500px;
   margin: auto;
   background-color: rgb(255, 221, 127);
   font-family: "Segoe UI", "Yu Gothic", sans-serif;

--- a/public/style.css
+++ b/public/style.css
@@ -24,6 +24,16 @@ container {
   top: 5px;
   left: 50px;
   font-size: 11px;
+  text-align: left;
+  white-space: nowrap;
+}
+
+#editor-mode-input {
+  position: absolute;
+  top: 5px;
+  left: calc(100%);
+  font-size: 11px;
+  text-align: left;
   white-space: nowrap;
 }
 
@@ -382,7 +392,7 @@ input[type="number"].editor-speed-piece::-webkit-inner-spin-button {
   justify-content: left;
   font-size: 16px;
   padding: 0 40px;
-  margin: 10px 0;
+  margin: 5px 0;
 }
 
 .configure-options {

--- a/public/style.css
+++ b/public/style.css
@@ -168,7 +168,6 @@ input[type="number"].editor-speed-piece::-webkit-inner-spin-button {
 .btn-purple {
   color: #9944ff;
   border: solid 2px #9944ff;
-  width: 100px;
 }
 
 .menu-output-btn:hover {

--- a/src/components/configure/ConfigureDesign.vue
+++ b/src/components/configure/ConfigureDesign.vue
@@ -3,6 +3,17 @@
     <h3 class="configure-context-title">Options</h3>
 
     <div class="configure-design-item">
+      <div class="configure-design-text">Click Mode:</div>
+      <div class="configure-options">
+        <div class="configure-radio">
+          <label> <input v-model="isClick" type="radio" class="uk-radio" name="editor-click" :value="true" />On </label>
+        </div>
+        <div class="configure-radio">
+          <label> <input v-model="isClick" type="radio" class="uk-radio" name="editor-click" :value="false" />Off </label>
+        </div>
+      </div>
+    </div>
+    <div class="configure-design-item">
       <div class="configure-design-text">Direction:</div>
       <div class="configure-options">
         <div class="configure-radio">
@@ -68,6 +79,18 @@ export default defineComponent({
     };
   },
   computed: {
+    isClick: {
+      get(): boolean {
+        const isClickStr: string = localStorage.getItem("isClick") ?? "false";
+        return JSON.parse(isClickStr);
+      },
+
+      set(newValue: boolean): boolean {
+        localStorage.setItem("isClick", JSON.stringify(newValue));
+        return newValue;
+      },
+    },
+
     isReverse: {
       get(): boolean {
         const isReverseStr: string = localStorage.getItem("isReverse") ?? "false";

--- a/src/components/configure/ConfigureDesign.vue
+++ b/src/components/configure/ConfigureDesign.vue
@@ -3,7 +3,18 @@
     <h3 class="configure-context-title">Options</h3>
 
     <div class="configure-design-item">
-      <div class="configure-design-text">Click Mode:</div>
+      <div class="configure-design-text">Keyboard Input:</div>
+      <div class="configure-options">
+        <div class="configure-radio">
+          <label> <input v-model="isKeyboard" type="radio" class="uk-radio" name="editor-keyboard" :value="true" />On </label>
+        </div>
+        <div class="configure-radio">
+          <label> <input v-model="isKeyboard" type="radio" class="uk-radio" name="editor-keyboard" :value="false" />Off </label>
+        </div>
+      </div>
+    </div>
+    <div class="configure-design-item">
+      <div class="configure-design-text">Click/Tap Input:</div>
       <div class="configure-options">
         <div class="configure-radio">
           <label> <input v-model="isClick" type="radio" class="uk-radio" name="editor-click" :value="true" />On </label>
@@ -79,6 +90,17 @@ export default defineComponent({
     };
   },
   computed: {
+    isKeyboard: {
+      get(): boolean {
+        const isKeyboardStr: string = localStorage.getItem("isKeyboard") ?? "true";
+        return JSON.parse(isKeyboardStr);
+      },
+
+      set(newValue: boolean): boolean {
+        localStorage.setItem("isKeyboard", JSON.stringify(newValue));
+        return newValue;
+      },
+    },
     isClick: {
       get(): boolean {
         const isClickStr: string = localStorage.getItem("isClick") ?? "false";

--- a/src/components/editor/EditorConstant.ts
+++ b/src/components/editor/EditorConstant.ts
@@ -5,7 +5,7 @@ export const verticalSizeNum = (num = 8) => quarterInterval * num;
 export const editorHeight = quarterInterval * 8;
 export const fps = 60;
 export const longTapThreshold = 250;
-export const divisors = [2, 4, 3, 6, 12, 8];
+export const divisors = [8, 16, 12, 24, 48, 32];
 
 export const canvasMarginHorizontal = 50;
 export const canvasMarginVertical = 25;

--- a/src/components/editor/EditorConstant.ts
+++ b/src/components/editor/EditorConstant.ts
@@ -5,7 +5,7 @@ export const verticalSizeNum = (num = 8) => quarterInterval * num;
 export const editorHeight = quarterInterval * 8;
 export const fps = 60;
 export const longTapThreshold = 250;
-export const divisors = [1, 2, 4, 3, 6, 12, 8];
+export const divisors = [2, 4, 3, 6, 12, 8];
 
 export const canvasMarginHorizontal = 50;
 export const canvasMarginVertical = 25;

--- a/src/components/editor/EditorConstant.ts
+++ b/src/components/editor/EditorConstant.ts
@@ -4,6 +4,7 @@ export const quarterInterval = 48;
 export const verticalSizeNum = (num = 8) => quarterInterval * num;
 export const editorHeight = quarterInterval * 8;
 export const fps = 60;
+export const longTapThreshold = 250;
 
 export const canvasMarginHorizontal = 50;
 export const canvasMarginVertical = 25;

--- a/src/components/editor/EditorConstant.ts
+++ b/src/components/editor/EditorConstant.ts
@@ -5,6 +5,7 @@ export const verticalSizeNum = (num = 8) => quarterInterval * num;
 export const editorHeight = quarterInterval * 8;
 export const fps = 60;
 export const longTapThreshold = 250;
+export const divisors = [1, 2, 4, 3, 6, 12, 8];
 
 export const canvasMarginHorizontal = 50;
 export const canvasMarginVertical = 25;

--- a/src/components/editor/EditorController.vue
+++ b/src/components/editor/EditorController.vue
@@ -1,6 +1,7 @@
 <template>
   <div id="editor-controller">
     <editor-main
+      ref="editorMain"
       :page-num="pageNum"
       :load-score-data="scoreData"
       :load-music-url="musicUrl"
@@ -68,11 +69,12 @@
       </div>
 
       <div id="menu-output" class="menu-item-container">
-        <a class="menu-output-btn btn-orange" uk-toggle="target: #editor-option">OPTION</a>
-        <div class="menu-output-btn btn-gray" @click="convertWithQuarters">TEST</div>
-        <div class="menu-output-btn btn-blue" uk-toggle="target: #editor-save">SAVE</div>
-        <div class="menu-output-btn btn-gray" @click="displayScoreDataInfo">CALC</div>
-        <div class="menu-output-btn btn-red" @click="convert">GO!</div>
+        <div class="menu-output-btn btn-purple btn-controller" id="ctrlPlay" @click="play">PLAY</div>
+        <a class="menu-output-btn btn-orange btn-controller" uk-toggle="target: #editor-option">OPTION</a>
+        <div class="menu-output-btn btn-gray btn-controller" @click="convertWithQuarters">TEST</div>
+        <div class="menu-output-btn btn-blue btn-controller" uk-toggle="target: #editor-save">SAVE</div>
+        <div class="menu-output-btn btn-gray btn-controller" @click="displayScoreDataInfo">CALC</div>
+        <div class="menu-output-btn btn-red btn-controller" @click="convert">GO!</div>
       </div>
     </div>
     <router-link
@@ -88,7 +90,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from "vue";
+import { defineComponent, ref } from "vue";
 import EditorMain from "./EditorMain.vue";
 import EditorOption from "./EditorOption.vue";
 import { Timing } from "../../model/Timing";
@@ -130,6 +132,18 @@ export default defineComponent({
     selectedKey: { type: String, required: true },
     loadScoreDataStr: { type: String, required: true },
     loadMusicUrl: { type: String, required: true },
+  },
+  setup() {
+    const editorMain = ref<typeof EditorMain>();
+    const play = () => {
+      if (editorMain.value) {
+        editorMain.value.togglePlay();
+      }
+    };
+    return {
+      editorMain,
+      play,
+    };
   },
   data(): DataType {
     const keyConfig = createCustomKeyConfig();

--- a/src/components/editor/EditorController.vue
+++ b/src/components/editor/EditorController.vue
@@ -149,7 +149,7 @@ export default defineComponent({
         if (divisorNum === Math.max(0, -multi * divisors.length - 1)) {
           editorMain.value.switchView(multi);
         }
-        editorMain.value.changeDivisor(quarterInterval / divisors[divisorNum]);
+        editorMain.value.changeDivisor(quarterInterval / (divisors[divisorNum] / 4));
       }
     };
     return {

--- a/src/components/editor/EditorController.vue
+++ b/src/components/editor/EditorController.vue
@@ -70,7 +70,8 @@
 
       <div id="menu-output" class="menu-item-container">
         <a class="menu-output-btn btn-orange btn-controller" uk-toggle="target: #editor-option">OPTION</a>
-        <div class="menu-output-btn btn-gray btn-controller" @click="changeDivisor()">>></div>
+        <div class="menu-output-btn btn-gray btn-controller btn-mini" @click="changeDivisor(-1)">&lt;</div>
+        <div class="menu-output-btn btn-gray btn-controller btn-mini" @click="changeDivisor()">&gt;</div>
         <div class="menu-output-btn btn-purple btn-controller" @click="play">PLAY</div>
         <div class="menu-output-btn btn-gray btn-controller" @click="convertWithQuarters">TEST</div>
         <div class="menu-output-btn btn-blue btn-controller" uk-toggle="target: #editor-save">SAVE</div>
@@ -142,9 +143,13 @@ export default defineComponent({
         editorMain.value.togglePlay();
       }
     };
-    const changeDivisor = () => {
+    const changeDivisor = (multi: number = 1) => {
       if (editorMain.value) {
-        editorMain.value.changeDivisor(quarterInterval / divisors[++divisorNum % divisors.length]);
+        divisorNum = (divisorNum + divisors.length + multi) % divisors.length;
+        if (divisorNum === Math.max(0, -multi * divisors.length - 1)) {
+          editorMain.value.switchView(multi);
+        }
+        editorMain.value.changeDivisor(quarterInterval / divisors[divisorNum]);
       }
     };
     return {

--- a/src/components/editor/EditorController.vue
+++ b/src/components/editor/EditorController.vue
@@ -69,8 +69,9 @@
       </div>
 
       <div id="menu-output" class="menu-item-container">
-        <div class="menu-output-btn btn-purple btn-controller" id="ctrlPlay" @click="play">PLAY</div>
         <a class="menu-output-btn btn-orange btn-controller" uk-toggle="target: #editor-option">OPTION</a>
+        <div class="menu-output-btn btn-gray btn-controller" @click="changeDivisor()">>></div>
+        <div class="menu-output-btn btn-purple btn-controller" @click="play">PLAY</div>
         <div class="menu-output-btn btn-gray btn-controller" @click="convertWithQuarters">TEST</div>
         <div class="menu-output-btn btn-blue btn-controller" uk-toggle="target: #editor-save">SAVE</div>
         <div class="menu-output-btn btn-gray btn-controller" @click="displayScoreDataInfo">CALC</div>
@@ -99,7 +100,7 @@ import { ScoreConvertService } from "./service/ScoreConvertService";
 import { LevelCalcService } from "./service/LevelCalcService";
 import { CustomKeyKind } from "../../model/KeyKind";
 import { CustomKeyConfig } from "../../model/KeyConfig";
-import { fps, quarterInterval, verticalSizeNum } from "./EditorConstant";
+import { divisors, fps, quarterInterval, verticalSizeNum } from "./EditorConstant";
 import { createCustomKeyConfig } from "../common/createCustomKeyConfig";
 import { DefaultPageScore } from "@/model/PageScore";
 import { ScoreRevivalService } from "./service/ScoreRevivalService";
@@ -134,15 +135,22 @@ export default defineComponent({
     loadMusicUrl: { type: String, required: true },
   },
   setup() {
+    let divisorNum: number = 0;
     const editorMain = ref<typeof EditorMain>();
     const play = () => {
       if (editorMain.value) {
         editorMain.value.togglePlay();
       }
     };
+    const changeDivisor = () => {
+      if (editorMain.value) {
+        editorMain.value.changeDivisor(quarterInterval / divisors[++divisorNum % divisors.length]);
+      }
+    };
     return {
       editorMain,
       play,
+      changeDivisor,
     };
   },
   data(): DataType {

--- a/src/components/editor/EditorMain.vue
+++ b/src/components/editor/EditorMain.vue
@@ -5,6 +5,7 @@
       ref="canvas"
       tabindex="-1"
       @keydown.prevent="keydownAction"
+      @wheel.prevent="wheelAction"
       @mouseup.prevent="clickAction"
       @touchstart.prevent="touchStartAction"
       @touchend.prevent="touchEndAction"
@@ -695,6 +696,7 @@ export default defineComponent({
       }
     },
 
+    // フォーカス時の処理（枠線変更）
     canvasFocusOrBlur(focusFlg: boolean = false): void {
       window.setTimeout(() => {
         this.hasCanvasFocus = focusFlg;
@@ -754,6 +756,16 @@ export default defineComponent({
       if (this.hasCanvasFocus) {
         this.clickTapAction(e.offsetX, e.offsetY, e.shiftKey || e.button === 1);
       }
+    },
+
+    // マウスホイール移動時の処理
+    wheelAction(e: WheelEvent): void {
+      if (!this.isClick) return;
+      const positionLineMove = (isRaise: boolean) => {
+        return isRaise === this.isReverse ? this.currentPositionDecrease : () => this.currentPositionIncrease(false);
+      };
+      if (e.deltaY > 0) positionLineMove(false)();
+      else if (e.deltaY < 0) positionLineMove(true)();
     },
 
     // クリック/タップ時の処理

--- a/src/components/editor/EditorMain.vue
+++ b/src/components/editor/EditorMain.vue
@@ -722,7 +722,7 @@ export default defineComponent({
         // リストに残っている(長押しとして処理されていない)ものは通常タップとして処理
         const start = this.longTouchList[touch.identifier];
         if (start) {
-          clearTimeout(start.timer);
+          clearTimeout(Number(start.timer));
           this.tapAction(start.touch, false);
           delete this.longTouchList[touch.identifier];
         }
@@ -732,7 +732,7 @@ export default defineComponent({
     // 長押しリストとタイマーのクリア
     clearLongTouchList() {
       Object.values(this.longTouchList).forEach((value) => {
-        clearTimeout(value.timer);
+        clearTimeout(Number(value.timer));
       });
       this.longTouchList = {};
     },

--- a/src/components/editor/EditorMain.vue
+++ b/src/components/editor/EditorMain.vue
@@ -21,8 +21,9 @@
       :type="speed.type"
       :is-reverse="isReverse"
     ></speed-piece>
-    <div id="editor-mode-text">
-      入力間隔: {{ mode }}分 ({{ moveIntervalFrame }}F) {{ isClick && !isWheelLock ? "Wheel: ON" : "" }}
+    <div id="editor-mode-text">入力間隔: {{ mode }}分 ({{ moveIntervalFrame }}F)</div>
+    <div id="editor-mode-input">
+      <b>{{ isKeyboard ? "[Key]" : "" }}{{ isClick ? "[Click]" : "" }}{{ isClick && !isWheelLock ? "[Wheel]" : "" }}</b>
     </div>
   </div>
 </template>
@@ -66,6 +67,7 @@ type DataType = {
   page: number;
   editorWidth: number;
   isReverse: boolean;
+  isKeyboard: boolean;
   isClick: boolean;
   isWheelLock: boolean;
   pageBlockNum: number;
@@ -116,6 +118,7 @@ export default defineComponent({
     const keyNum = keyConfig[keyKind].num;
     const isReverseStr: string = localStorage.getItem("isReverse") ?? "false";
     const isReverse: boolean = JSON.parse(isReverseStr);
+    const isKeyboard: boolean = JSON.parse(localStorage.getItem("isKeyboard") ?? "true");
     const isClick: boolean = JSON.parse(localStorage.getItem("isClick") ?? "false");
     const pageBlockNum = parseInt(JSON.parse(localStorage.getItem("pageBlockNum") ?? "8"));
     const operationStack: Operation[] = [];
@@ -147,6 +150,7 @@ export default defineComponent({
       page: 1,
       keyNum,
       isReverse,
+      isKeyboard,
       isClick,
       isWheelLock: false,
       editorWidth: noteWidth * keyConfig[keyKind].num,
@@ -607,7 +611,17 @@ export default defineComponent({
             this.switchView();
             break;
           }
-          case "Digit0": {
+          case "Comma": {
+            this.isKeyboard = !this.isKeyboard;
+            localStorage.setItem("isKeyboard", JSON.stringify(this.isKeyboard));
+            break;
+          }
+          case "Period": {
+            this.isClick = !this.isClick;
+            localStorage.setItem("isClick", JSON.stringify(this.isClick));
+            break;
+          }
+          case "Slash": {
             this.isWheelLock = !this.isWheelLock;
             break;
           }
@@ -674,7 +688,7 @@ export default defineComponent({
 
             const orderGroup: number[] = this.orderGroups[this.orderGroupNo];
             const orgLane: number = orderGroup.indexOf(possiblyLane);
-            if (possiblyLane >= 0) {
+            if (possiblyLane >= 0 && this.isKeyboard) {
               // 一定時間内に押されたときは直前の位置にノートを追加/削除する
               const now = new Date();
               const threshold: number = JSON.parse(localStorage.getItem("simultaneousThreshold") ?? "30");

--- a/src/components/editor/EditorMain.vue
+++ b/src/components/editor/EditorMain.vue
@@ -748,9 +748,9 @@ export default defineComponent({
       this.clickTapAction(offsetX, offsetY, longTap);
     },
 
-    // クリック時の処理
+    // クリック時の処理（クリックモードかつ左クリック時のみ有効）
     clickAction(e: MouseEvent): void {
-      if (!this.isClick) return;
+      if (!this.isClick || e.button !== 0) return;
       if (this.hasCanvasFocus) {
         this.clickTapAction(e.offsetX, e.offsetY, e.shiftKey);
       }

--- a/src/components/editor/EditorMain.vue
+++ b/src/components/editor/EditorMain.vue
@@ -780,7 +780,7 @@ export default defineComponent({
         if (possiblyLane >= 0 && possiblyLane < this.keyNum) {
           // ノートの追加/削除
           this.addNote(this.noteService as NoteService, this.page, position, convLane, shiftKey, lane);
-        } else if (possiblyLane >= this.keyNum && possiblyLane < this.keyNum + 0.5) {
+        } else if (possiblyLane >= this.keyNum && possiblyLane < this.keyNum + 0.75) {
           // 速度変化の追加/削除
           this.addSpeedPiece(this.speedPieceService as SpeedPieceService, this.page, position, shiftKey);
         }

--- a/src/components/editor/EditorMain.vue
+++ b/src/components/editor/EditorMain.vue
@@ -748,11 +748,11 @@ export default defineComponent({
       this.clickTapAction(offsetX, offsetY, longTap);
     },
 
-    // クリック時の処理（クリックモードかつ左クリック時のみ有効）
+    // クリック時の処理（左クリックでノート、ホイールボタンでフリーズノート）
     clickAction(e: MouseEvent): void {
-      if (!this.isClick || e.button !== 0) return;
+      if (!this.isClick || e.button >= 2) return;
       if (this.hasCanvasFocus) {
-        this.clickTapAction(e.offsetX, e.offsetY, e.shiftKey);
+        this.clickTapAction(e.offsetX, e.offsetY, e.shiftKey || e.button === 1);
       }
     },
 

--- a/src/components/editor/EditorMain.vue
+++ b/src/components/editor/EditorMain.vue
@@ -21,7 +21,9 @@
       :type="speed.type"
       :is-reverse="isReverse"
     ></speed-piece>
-    <div id="editor-mode-text">入力間隔: {{ mode }}分 ({{ moveIntervalFrame }}F)</div>
+    <div id="editor-mode-text">
+      入力間隔: {{ mode }}分 ({{ moveIntervalFrame }}F) {{ isClick && !isWheelLock ? "Wheel: ON" : "" }}
+    </div>
   </div>
 </template>
 
@@ -65,6 +67,7 @@ type DataType = {
   editorWidth: number;
   isReverse: boolean;
   isClick: boolean;
+  isWheelLock: boolean;
   pageBlockNum: number;
   musicTimer: number | null;
   musicService?: MusicService;
@@ -145,6 +148,7 @@ export default defineComponent({
       keyNum,
       isReverse,
       isClick,
+      isWheelLock: false,
       editorWidth: noteWidth * keyConfig[keyKind].num,
       pageBlockNum,
       musicTimer: null,
@@ -603,6 +607,10 @@ export default defineComponent({
             this.switchView();
             break;
           }
+          case "Digit0": {
+            this.isWheelLock = !this.isWheelLock;
+            break;
+          }
         }
       };
 
@@ -761,7 +769,7 @@ export default defineComponent({
 
     // マウスホイール移動時の処理
     wheelAction(e: WheelEvent): void {
-      if (!this.isClick) return;
+      if (!this.isClick || this.isWheelLock) return;
       const positionLineMove = (isRaise: boolean) => {
         return isRaise === this.isReverse ? this.currentPositionDecrease : () => this.currentPositionIncrease(false);
       };

--- a/src/components/editor/EditorMain.vue
+++ b/src/components/editor/EditorMain.vue
@@ -63,6 +63,7 @@ type DataType = {
   page: number;
   editorWidth: number;
   isReverse: boolean;
+  isClick: boolean;
   pageBlockNum: number;
   musicTimer: number | null;
   musicService?: MusicService;
@@ -111,6 +112,7 @@ export default defineComponent({
     const keyNum = keyConfig[keyKind].num;
     const isReverseStr: string = localStorage.getItem("isReverse") ?? "false";
     const isReverse: boolean = JSON.parse(isReverseStr);
+    const isClick: boolean = JSON.parse(localStorage.getItem("isClick") ?? "false");
     const pageBlockNum = parseInt(JSON.parse(localStorage.getItem("pageBlockNum") ?? "8"));
     const operationStack: Operation[] = [];
     const defaultOrder: number[][] = [[...Array(keyConfig[keyKind].num)].map((_: undefined, idx: number) => idx)];
@@ -141,6 +143,7 @@ export default defineComponent({
       page: 1,
       keyNum,
       isReverse,
+      isClick,
       editorWidth: noteWidth * keyConfig[keyKind].num,
       pageBlockNum,
       musicTimer: null,
@@ -723,6 +726,7 @@ export default defineComponent({
 
     // タッチ開始時
     touchStartAction(e: TouchEvent) {
+      if (!this.isClick) return;
       Array.from(e.changedTouches).forEach((touch) => {
         // 一定時間後に長押しとして処理する
         const timer = setTimeout(() => {
@@ -735,6 +739,7 @@ export default defineComponent({
 
     // タッチ終了時
     touchEndAction(e: TouchEvent) {
+      if (!this.isClick) return;
       Array.from(e.changedTouches).forEach((touch) => {
         // リストに残っている(長押しとして処理されていない)ものは通常タップとして処理
         const start = this.longTouchList[touch.identifier];
@@ -767,6 +772,7 @@ export default defineComponent({
 
     // クリック時の処理
     clickAction(e: MouseEvent) {
+      if (!this.isClick) return;
       if (this.hasCanvasFocus) {
         this.clickTapAction(e.offsetX, e.offsetY, e.shiftKey);
       }

--- a/src/components/editor/EditorMain.vue
+++ b/src/components/editor/EditorMain.vue
@@ -7,6 +7,7 @@
       @keydown.prevent="keydownAction"
       @wheel.prevent="wheelAction"
       @mouseup.prevent="clickAction"
+      @mousedown.middle.prevent=""
       @touchstart.prevent="touchStartAction"
       @touchend.prevent="touchEndAction"
       @focus="canvasFocusOrBlur(true)"

--- a/src/components/editor/EditorMain.vue
+++ b/src/components/editor/EditorMain.vue
@@ -558,6 +558,14 @@ export default defineComponent({
       }
     },
 
+    // 表示切替
+    switchView(multi: number = 1) {
+      this.orderGroupNo = (this.orderGroupNo + this.orderGroups.length + multi) % this.orderGroups.length;
+      this.baseLayerDraw();
+      this.pageMove(this.page);
+      this.displayPageScore(this.page);
+    },
+
     // キーを押したときの挙動
     keydownAction(e: KeyboardEvent): void {
       const noteService = this.noteService as NoteService;
@@ -609,10 +617,7 @@ export default defineComponent({
             break;
           }
           case "KeyQ": {
-            this.orderGroupNo = (this.orderGroupNo + 1) % this.orderGroups.length;
-            this.baseLayerDraw();
-            this.pageMove(page);
-            this.displayPageScore(page);
+            this.switchView();
             break;
           }
         }

--- a/src/components/editor/EditorMain.vue
+++ b/src/components/editor/EditorMain.vue
@@ -790,8 +790,10 @@ export default defineComponent({
           this.addSpeedPiece(this.speedPieceService as SpeedPieceService, this.page, position, shiftKey);
         }
         // カーソルの移動
-        this.currentPosition = position;
-        this.currentPositionService.move(this.currentPosition, this.page, this.timing);
+        if (possiblyLane < this.keyNum + 0.75) {
+          this.currentPosition = position;
+          this.currentPositionService.move(this.currentPosition, this.page, this.timing);
+        }
       }
     },
   },

--- a/src/components/editor/EditorMain.vue
+++ b/src/components/editor/EditorMain.vue
@@ -43,7 +43,6 @@ import {
 } from "./EditorConstant";
 import { Timing } from "../../model/Timing";
 import { MusicService } from "./service/MusicService";
-import { SpeedType } from "../../model/Speed";
 import { Operation } from "../../model/OperationQueue";
 import { NoteService } from "./service/NoteService";
 import { SpeedPieceService } from "./service/SpeedPieceService";
@@ -540,35 +539,6 @@ export default defineComponent({
       }
     },
 
-    // ノートの追加/削除
-    addNote(
-      noteService: NoteService,
-      prevPage: number,
-      page: number,
-      position: number,
-      lane: number,
-      isFreeze: boolean,
-      orgLane: number = lane
-    ) {
-      if (noteService.hasNote(prevPage, lane, position).exists) {
-        noteService.removeOne(prevPage, page, lane, position, orgLane);
-      } else {
-        noteService.addOne(prevPage, page, lane, position, isFreeze, orgLane);
-      }
-    },
-
-    // 速度変化の追加/削除
-    addSpeedPiece(speedPieceService: SpeedPieceService, page: number, position: number, isBoost: boolean) {
-      const speedType: SpeedType = isBoost ? "boost" : "speed";
-      if (speedPieceService.hasSpeedPiece(page, position)) {
-        speedPieceService.remove(page, position);
-        speedPieceService.clear(position);
-      } else {
-        speedPieceService.add(page, position, speedType);
-        speedPieceService.draw(position, speedType);
-      }
-    },
-
     // 表示切替
     switchView(multi: number = 1) {
       this.orderGroupNo = (this.orderGroupNo + this.orderGroups.length + multi) % this.orderGroups.length;
@@ -677,7 +647,7 @@ export default defineComponent({
             else this.pagePlus(1);
             break;
           case "Quote":
-            this.addSpeedPiece(speedPieceService, this.page, this.currentPosition, e.shiftKey);
+            speedPieceService.switchOne(this.page, this.currentPosition, e.shiftKey);
             break;
 
           default: {
@@ -708,7 +678,7 @@ export default defineComponent({
               }
 
               // ノートの追加/削除
-              this.addNote(noteService, page, this.page, position, possiblyLane, isFreeze, orgLane);
+              noteService.switchOne(page, this.page, possiblyLane, position, isFreeze, orgLane);
 
               // 同時押しのときはカーソルを進めない
               if (!isSimultaneous) {
@@ -798,10 +768,10 @@ export default defineComponent({
       if (position >= 0 && position < verticalSizeNum()) {
         if (possiblyLane >= 0 && possiblyLane < this.keyNum) {
           // ノートの追加/削除
-          this.addNote(this.noteService as NoteService, this.page, this.page, position, convLane, shiftKey, lane);
+          this.noteService?.switchOne(this.page, this.page, convLane, position, shiftKey, lane);
         } else if (possiblyLane >= this.keyNum && possiblyLane < this.keyNum + 0.75) {
           // 速度変化の追加/削除
-          this.addSpeedPiece(this.speedPieceService as SpeedPieceService, this.page, position, shiftKey);
+          this.speedPieceService?.switchOne(this.page, position, shiftKey);
         }
         // カーソルの移動
         if (possiblyLane < this.keyNum + 0.75) {

--- a/src/components/editor/EditorMain.vue
+++ b/src/components/editor/EditorMain.vue
@@ -541,11 +541,19 @@ export default defineComponent({
     },
 
     // ノートの追加/削除
-    addNote(noteService: NoteService, page: number, position: number, lane: number, isFreeze: boolean, orgLane: number = lane) {
-      if (noteService.hasNote(page, lane, position).exists) {
-        noteService.removeOne(page, page, lane, position, orgLane);
+    addNote(
+      noteService: NoteService,
+      prevPage: number,
+      page: number,
+      position: number,
+      lane: number,
+      isFreeze: boolean,
+      orgLane: number = lane
+    ) {
+      if (noteService.hasNote(prevPage, lane, position).exists) {
+        noteService.removeOne(prevPage, page, lane, position, orgLane);
       } else {
-        noteService.addOne(page, page, lane, position, isFreeze, orgLane);
+        noteService.addOne(prevPage, page, lane, position, isFreeze, orgLane);
       }
     },
 
@@ -700,7 +708,7 @@ export default defineComponent({
               }
 
               // ノートの追加/削除
-              this.addNote(noteService, this.page, position, possiblyLane, isFreeze, orgLane);
+              this.addNote(noteService, page, this.page, position, possiblyLane, isFreeze, orgLane);
 
               // 同時押しのときはカーソルを進めない
               if (!isSimultaneous) {
@@ -790,7 +798,7 @@ export default defineComponent({
       if (position >= 0 && position < verticalSizeNum()) {
         if (possiblyLane >= 0 && possiblyLane < this.keyNum) {
           // ノートの追加/削除
-          this.addNote(this.noteService as NoteService, this.page, position, convLane, shiftKey, lane);
+          this.addNote(this.noteService as NoteService, this.page, this.page, position, convLane, shiftKey, lane);
         } else if (possiblyLane >= this.keyNum && possiblyLane < this.keyNum + 0.75) {
           // 速度変化の追加/削除
           this.addSpeedPiece(this.speedPieceService as SpeedPieceService, this.page, position, shiftKey);

--- a/src/components/editor/EditorMain.vue
+++ b/src/components/editor/EditorMain.vue
@@ -711,7 +711,7 @@ export default defineComponent({
           this.tapAction(touch, true);
           delete this.longTouchList[touch.identifier];
         }, longTapThreshold);
-        this.longTouchList[touch.identifier] = { touch: touch, timer: timer };
+        this.longTouchList[touch.identifier] = { touch, timer };
       });
     },
 

--- a/src/components/editor/EditorMain.vue
+++ b/src/components/editor/EditorMain.vue
@@ -86,7 +86,7 @@ type DataType = {
   alternativeKeysFull: string[][];
   orderKeyTypes: number[];
   hasCanvasFocus: boolean;
-  longTouchList: { [name: number]: { timer: NodeJS.Timer; touch: Touch } };
+  longTouchList: { [name: number]: { timer: number; touch: Touch } };
 };
 
 export default defineComponent({
@@ -513,7 +513,7 @@ export default defineComponent({
     currentPositionIncrease(withThreshold: boolean) {
       const threshold: number = JSON.parse(localStorage.getItem("simultaneousThreshold") ?? "30");
       if (this.currentPosition + this.divisor >= verticalSizeNum(this.pageBlockNum)) {
-        if (withThreshold) setTimeout(() => this.pagePlus(1), threshold);
+        if (withThreshold) window.setTimeout(() => this.pagePlus(1), threshold);
         else this.pagePlus(1);
       } else {
         this.currentPositionService.move(this.currentPosition + this.divisor, this.page, this.timing);
@@ -529,7 +529,7 @@ export default defineComponent({
     },
 
     // 音楽の再生/停止
-    togglePlay() {
+    togglePlay(): void {
       if (!this.musicTimer) {
         const timing = this.timing;
         this.playMusicLoop(timing);
@@ -540,7 +540,7 @@ export default defineComponent({
     },
 
     // 表示切替
-    switchView(multi: number = 1) {
+    switchView(multi: number = 1): void {
       this.orderGroupNo = (this.orderGroupNo + this.orderGroups.length + multi) % this.orderGroups.length;
       this.baseLayerDraw();
       this.pageMove(this.page);
@@ -663,7 +663,7 @@ export default defineComponent({
             let isSimultaneous = false;
 
             const orderGroup: number[] = this.orderGroups[this.orderGroupNo];
-            const orgLane = orderGroup.indexOf(possiblyLane);
+            const orgLane: number = orderGroup.indexOf(possiblyLane);
             if (possiblyLane >= 0) {
               // 一定時間内に押されたときは直前の位置にノートを追加/削除する
               const now = new Date();
@@ -695,19 +695,19 @@ export default defineComponent({
       }
     },
 
-    canvasFocusOrBlur(focusFlg: boolean = false) {
-      setTimeout(() => {
+    canvasFocusOrBlur(focusFlg: boolean = false): void {
+      window.setTimeout(() => {
         this.hasCanvasFocus = focusFlg;
         this.baseLayerDraw();
       }, 100);
     },
 
     // タッチ開始時
-    touchStartAction(e: TouchEvent) {
+    touchStartAction(e: TouchEvent): void {
       if (!this.isClick) return;
       Array.from(e.changedTouches).forEach((touch) => {
         // 一定時間後に長押しとして処理する
-        const timer = setTimeout(() => {
+        const timer: number = window.setTimeout(() => {
           this.tapAction(touch, true);
           delete this.longTouchList[touch.identifier];
         }, longTapThreshold);
@@ -716,13 +716,13 @@ export default defineComponent({
     },
 
     // タッチ終了時
-    touchEndAction(e: TouchEvent) {
+    touchEndAction(e: TouchEvent): void {
       if (!this.isClick) return;
       Array.from(e.changedTouches).forEach((touch) => {
         // リストに残っている(長押しとして処理されていない)ものは通常タップとして処理
         const start = this.longTouchList[touch.identifier];
         if (start) {
-          clearTimeout(Number(start.timer));
+          window.clearTimeout(start.timer);
           this.tapAction(start.touch, false);
           delete this.longTouchList[touch.identifier];
         }
@@ -730,26 +730,26 @@ export default defineComponent({
     },
 
     // 長押しリストとタイマーのクリア
-    clearLongTouchList() {
+    clearLongTouchList(): void {
       Object.values(this.longTouchList).forEach((value) => {
-        clearTimeout(Number(value.timer));
+        window.clearTimeout(value.timer);
       });
       this.longTouchList = {};
     },
 
     // タップ時の処理
     // TouchEventはoffsetX,Yが無いためclientX,Yから計算
-    tapAction(touch: Touch, longTap: boolean) {
+    tapAction(touch: Touch, longTap: boolean): void {
       if (touch.target === null) return;
       const target = touch.target as HTMLElement;
       const rect = target.getBoundingClientRect();
-      const offsetX = touch.clientX - rect.x;
-      const offsetY = touch.clientY - rect.y;
+      const offsetX: number = touch.clientX - rect.x;
+      const offsetY: number = touch.clientY - rect.y;
       this.clickTapAction(offsetX, offsetY, longTap);
     },
 
     // クリック時の処理
-    clickAction(e: MouseEvent) {
+    clickAction(e: MouseEvent): void {
       if (!this.isClick) return;
       if (this.hasCanvasFocus) {
         this.clickTapAction(e.offsetX, e.offsetY, e.shiftKey);
@@ -757,13 +757,13 @@ export default defineComponent({
     },
 
     // クリック/タップ時の処理
-    clickTapAction(offsetX: number, offsetY: number, shiftKey: boolean) {
-      const possiblyLane = (offsetX - canvasMarginHorizontal) / noteWidth;
-      const lane = Math.floor(possiblyLane);
+    clickTapAction(offsetX: number, offsetY: number, shiftKey: boolean): void {
+      const possiblyLane: number = (offsetX - canvasMarginHorizontal) / noteWidth;
+      const lane: number = Math.floor(possiblyLane);
       const orderGroup: number[] = this.orderGroups[this.orderGroupNo];
-      const convLane = orderGroup[lane];
-      const y = this.isReverse ? offsetY - canvasMarginVertical : editorHeight - (offsetY - canvasMarginVertical);
-      const position = Math.floor((y * verticalSizeNum()) / editorHeight / this.divisor + 0.5) * this.divisor;
+      const convLane: number = orderGroup[lane];
+      const y: number = this.isReverse ? offsetY - canvasMarginVertical : editorHeight - (offsetY - canvasMarginVertical);
+      const position: number = Math.floor((y * verticalSizeNum()) / editorHeight / this.divisor + 0.5) * this.divisor;
 
       if (position >= 0 && position < verticalSizeNum()) {
         if (possiblyLane >= 0 && possiblyLane < this.keyNum) {

--- a/src/components/editor/EditorMain.vue
+++ b/src/components/editor/EditorMain.vue
@@ -371,6 +371,7 @@ export default defineComponent({
         height: editorHeight,
         stroke: this.hasCanvasFocus ? "#333333" : "#cccccc",
         strokeWidth: 1,
+        fill: this.hasCanvasFocus ? "#00000000" : "#cccccc33",
       });
       baseLayer.add(rect);
 

--- a/src/components/editor/EditorMain.vue
+++ b/src/components/editor/EditorMain.vue
@@ -23,7 +23,7 @@
     ></speed-piece>
     <div id="editor-mode-text">入力間隔: {{ mode }}分 ({{ moveIntervalFrame }}F)</div>
     <div id="editor-mode-input">
-      <b>{{ isKeyboard ? "[Key]" : "" }}{{ isClick ? "[Click]" : "" }}{{ isClick && !isWheelLock ? "[Wheel]" : "" }}</b>
+      {{ isKeyboard ? "[Key]" : "" }}{{ isClick ? "[Click]" : "" }}{{ isClick && !isWheelLock ? "[Wheel]" : "" }}
     </div>
   </div>
 </template>

--- a/src/components/editor/service/CurrentPositionService.ts
+++ b/src/components/editor/service/CurrentPositionService.ts
@@ -117,7 +117,7 @@ export class CurrentPositionService {
       y: toPx(verticalSizeNum(this.pageBlockNum), this.isReverse),
     });
 
-    setTimeout(() => {
+    window.setTimeout(() => {
       tween.play();
     }, (playDuration * 2) / (2 + this.pageBlockNum)); // 2拍後にアニメーション開始
   }

--- a/src/components/editor/service/MusicService.ts
+++ b/src/components/editor/service/MusicService.ts
@@ -60,7 +60,7 @@ export class MusicService {
     if (this.isPlaying) {
       this.source.stop(0);
     }
-    clearTimeout(timer);
+    window.clearTimeout(timer);
     this.isPlaying = false;
   }
 

--- a/src/components/editor/service/NoteService.ts
+++ b/src/components/editor/service/NoteService.ts
@@ -118,6 +118,15 @@ export class NoteService {
     });
   }
 
+  // ノーツの追加・削除
+  switchOne(page: number, displayPage: number, lane: number, position: number, isFreeze: boolean, orgLane: number = lane) {
+    if (this.hasNote(page, lane, position).exists) {
+      this.removeOne(page, displayPage, lane, position, orgLane);
+    } else {
+      this.addOne(page, displayPage, lane, position, isFreeze, orgLane);
+    }
+  }
+
   // フリーズの塗りつぶし描画
   fillFreeze(page: number, lane: number, orgLane: number = lane) {
     if (!this.isHighlightedFreeze) return false;

--- a/src/components/editor/service/NoteService.ts
+++ b/src/components/editor/service/NoteService.ts
@@ -86,11 +86,17 @@ export class NoteService {
 
   // 1ノーツを追加して描画
   addOne(page: number, displayPage: number, lane: number, position: number, isFreeze: boolean, orgLane: number = lane) {
-    this.add(page, lane, position, isFreeze);
+    const frzList = [];
+    this.scoreData.scores.forEach((score) => frzList.push(...score.freezes[lane]));
+
+    // フリーズノートが奇数の場合はシフトキーが無くてもフリーズノート扱いにする
+    const isFreezeFlg = isFreeze || frzList.length % 2 !== 0;
+
+    this.add(page, lane, position, isFreezeFlg);
     if (page === displayPage) {
-      this.draw(lane, position, isFreeze, orgLane);
+      this.draw(lane, position, isFreezeFlg, orgLane);
     }
-    if (isFreeze) this.fillFreeze(displayPage, lane, orgLane);
+    if (isFreezeFlg) this.fillFreeze(displayPage, lane, orgLane);
     this.stackPush({
       type: "ADD_NOTE",
       page,

--- a/src/components/editor/service/SpeedPieceService.ts
+++ b/src/components/editor/service/SpeedPieceService.ts
@@ -63,4 +63,16 @@ export class SpeedPieceService {
     note?.destroy();
     stage.add(notesLayer);
   }
+
+  // 速度変化コマの追加・削除
+  switchOne(page: number, position: number, isBoost: boolean) {
+    const speedType: SpeedType = isBoost ? "boost" : "speed";
+    if (this.hasSpeedPiece(page, position)) {
+      this.remove(page, position);
+      this.clear(position);
+    } else {
+      this.add(page, position, speedType);
+      this.draw(position, speedType);
+    }
+  }
 }


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
- このPRは、2年前くらいにすずめさんがfork-branchで作っていたものをベースに、
今の機能に対応するように微修正したものです。
- 当時の経緯は不明ですが、ショートカットコマンドを除いてほぼできていたので機能的には一応使える状態です。

### 1. クリック・タップモードの導入
- エディター画面からのクリック・タップ入力に対応しました。
- デフォルトは使用しない設定になっています。
Configureもしくはエディターのショートカットキーから切り替えます。

### 設定仕様（Configure追加部分）

|設定名|デフォルト|設定内容|
|----|----|----|
|Keyboard Input|on|キーボードからのノート入力の有効・無効を切り替えます。<br>「off」にした場合でも、キーボードショートカットはそのまま使用できます。|
|Click/Tap Input|**off**|マウスクリック・タップからのノート入力の有効・無効を切り替えます。<br>有効時は、マウスホイールによるカーソル移動も有効化されます。<br>（エディター画面にて無効化可能）|

### ショートカット仕様（エディター本体追加部分）
- エディター画面上で設定内容が確認できるように、画面右上にマークを入れるようにしました。

|ショートカット|マーク|対応内容|
|----|----|----|
|`Ctrl`+`, (カンマ)`|`[Key]`|キーボードからのノート入力の有効・無効を切り替え|
|`Ctrl`+`. (ピリオド)`|`[Click]`|マウスクリック・タップからのノート入力の有効・無効を切り替え|
|`Ctrl`+`/`|`[Wheel]`|マウスクリック・タップからのノート入力が有効のとき、<br>マウスホイールによるカーソル移動の有効・無効を切り替え|

### Click/Tap Inputを「on」にした場合の動作仕様
- マウスクリックもしくはタップでノート、ホイールクリックもしくはタップ長押しでフリーズノートを配置します。
- フォーカス外でマウスクリックが行われる可能性があるため、マウス／タップがエディター本体の枠内（厳密にはページ移動などがある部分を除いたエリア）に入ったときは枠色が黒になり、外れると薄い灰色になるようにしています。
- スマホ操作用に、音楽の「PLAY」ボタン、入力間隔／表示切替を変更する「<」「>」ボタンを追加しています（暫定措置）。入力間隔を変更するボタンは、ボタンを押すごとに入力間隔が切り替わる仕組みです。
クリックでは利用頻度の低そうな4分間隔モードは除外しています。

### 2. 対となるフリーズノートがいないとき、シフトキーが無くてもフリーズノートを選択したことにする変更
- 1.に関連する変更です。
対となるフリーズノートがいないとき、シフトキーなしでフリーズノートを配置/解除するようにしました。

### 3. その他
- 従来のキーボードの処理と被る箇所は極力共通処理にしました。
- ver 3.3.0で追加した表示切替にも対応しています。
- マウス／タップで速度変化コマやカーソルが反応する範囲を枠外から1コマの75％程度で反応するようにしています。
（キーボード側と機能併用なので、フォーカスを外すつもりで速度変化が配置される誤動作を考慮）
- setTimeout/clearTimeoutについてブラウザ側のものを使うように明示しました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
1. Resolves #52 
2. フリーズノートは対で配置されるもののため。
3. 現在の機能差の穴埋めと、既存機能と重複する処理を極力止めることで二重実装を防ぐため。

## :camera: スクリーンショット / Screenshot
### コンフィグ画面
- 設定項目に「Keyboard Input」「Click/Tap Input」を追加しました。
- 項目が増えたので、設定項目間の間隔を少し詰めました。
※ KeyConfig にいる「DL」ボタンは #117 での追加項目です。

<img src="https://github.com/user-attachments/assets/f9eb103e-53c7-4695-9336-01dfda7f8bfd" width="60%">

### フォーカスが当たっている／いないで枠線の色が変わる例
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img src="https://github.com/user-attachments/assets/360f8016-5bb8-402d-b588-47347cde7098" width="30%"><img src="https://github.com/user-attachments/assets/50aed55c-d75e-4789-ac71-4de423656586" width="30%">


## :pencil: その他コメント / Other Comments
### 内部的な仕様変化点
### style.css
#### エディター本体
- キーボード/クリック入力かを判別する表示エリア (editor-mode-input) を追加しました。
- editor-mode-text について、明示的に左寄せ設定にしました。
- btn-controller (エディター本体のボタン全般), btn-mini (&lt; &gt; ボタン), btn-purple (PLAYボタン) を追加しました。

#### Configure画面
- configure-containerの高さを 475px ⇒ 500px にしました。（項目追加のため）
- configure-design-item の縦マージンを 10px ⇒ 5px にしました。（項目追加のため）

### EditorMain.vue
- 以下の処理をメイン側に設定しました。

|種類|実行関数名|主な処理内容|
|----|----|----|
|@wheel.prevent|wheelAction|ホイール時のカーソル移動|
|@mouseup.prevent|clickAction|マウス/ホイールクリック時のコマ追加・除去処理<br>（右クリック時は処理せず、コンテキストメニューはそのまま<br>　フォーカス処理があるのでmousedownとしない）|
|@mousedown.middle.prevent|ー|ホイールクリック時、ホイールが出ないように定義だけ指定|
|@touchstart.prevent|touchStartAction|タップ開始時の処理（長押し開始処理とコマ追加・除去）|
|@touchend.prevent|touchEndAction|タップ終了時の処理（長押し終了検知とコマ追加・除去）|
|<span>@</span>focus|canvasFocusOrBlur|画面がフォーカスに入ったときの処理。枠線を再描画|
|<span>@</span>blur|canvasFocusOrBlur|画面がフォーカスから外れたときの処理。枠線を再描画|

#### 参考）関数の関係性
- wheelAction
- clickAction -> clickTapAction
- touchStartAction -> tapAction (長押し時) -> clickTapAction
- touchEndAction -> tapAction (長押し以外) -> clickTapAction
- canvasFocusOrBlur -> baseLayerDraw

#### ショートカットキーの追加
- 上述のショートカットキー追加に伴う変更です。
- キーボード入力・クリック入力の設定切り替えに対して、設定時にLocalStorageへの格納も行っています。

### ConfigureDesign.vue
- Keyboard Input, Click/Tap Input の設定追加による項目追加を行っています。

|項目名|対応するLocalStorage|デフォルト値|
|----|----|----|
|Keyboard Input|isKeyboard|`true`|
|Click/Tap Input|isClick|`false`|

### EditorConstant.ts
- 以下の2項目を追加しています。
  - `longTapThreshold`: 長押しとして処理する最小時間（ms）
  - `divisors`: 「&lt;」「&gt;」ボタンで制御できる入力間隔パターンを定義

### EditorController.vue
- `PLAY`ボタン、入力間隔・表示切替の変更処理（&lt; &gt;）ボタンを追加しています。
- また、これらの処理はエディター本体側で処理させるため、`setup()`を追加しています。
- 全体的にボタンが入らないため、高さ調整用のCSSクラス「btn-controller」を追加しました。

### NoteService.ts
- ノートの有無を検知し、ノートを配置するか除去するかを行う処理を一連のmethodにしました。
- 2.の変更のため、addOneのメソッドに一部手を加えています。

### SpeedPieceService.ts
- 速度変化ノートの有無を検知し、速度変化ノートを配置するか除去するかを行う処理を一連のmethodにしました。

### CurrentPositionService.ts / MusicService.ts
- setTimeout / clearTimeout関数について、window.を明示しnumber型で対応できるようにしました。

### コメント
- コピー＆ペーストなどの機能を今後ボタン化する場合、エディターの上部に置くという手もありますが、
今のページ構成を外れた対応になるので、このPRとしてはここまでにしたいと思います。

<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
