### PR TITLE
feat: カスタム定義のダウンロード・差分アップロードに対応

### DIFF
--- a/src/components/configure/ConfigureMain.vue
+++ b/src/components/configure/ConfigureMain.vue
@@ -26,6 +26,7 @@
 import { defineComponent } from "vue";
 import ConfigureUploader from "./ConfigureUploader.vue";
 import ConfigureDesign from "./ConfigureDesign.vue";
+import { createCustomKeyConfig } from "../common/createCustomKeyConfig";
 
 export default defineComponent({
   name: "ConfigureMain",
@@ -51,16 +52,21 @@ export default defineComponent({
             try {
               const customKeyConfigNew = JSON.parse(result);
               const customKeyConfigBase = JSON.parse(storage.getItem("customKeyConfig") || "{}");
-              const baseLength = Object.keys(customKeyConfigBase).length;
+              const importKeyList = Object.keys(customKeyConfigNew);
+              const dupliKeyStr = importKeyList.filter((key) => Object.keys(createCustomKeyConfig()).includes(key)).join(", ");
+              let importFlg: boolean = true;
+
               Object.assign(customKeyConfigBase, customKeyConfigNew);
-              if (baseLength + Object.keys(customKeyConfigNew).length > Object.keys(customKeyConfigBase).length) {
-                if (window.confirm("すでに定義済みのカスタムキー設定があります。上書きしてもよろしいですか？")) {
-                  storage.setItem("customKeyConfig", JSON.stringify(customKeyConfigBase, null, 2));
-                  alert("コンフィグファイルをインポートしました。");
+              if (dupliKeyStr !== ``) {
+                if (
+                  !window.confirm(`すでに定義済みのキー設定があります。上書きしてもよろしいですか？\r\n[対象キー:${dupliKeyStr}]`)
+                ) {
+                  importFlg = false;
                 }
-              } else {
+              }
+              if (importFlg) {
                 storage.setItem("customKeyConfig", JSON.stringify(customKeyConfigBase, null, 2));
-                alert("コンフィグファイルをインポートしました。");
+                alert(`コンフィグファイルをインポートしました。\r\n[対象キー:${importKeyList.join(", ")}]`);
               }
             } catch {
               alert("内容がJSON形式になっていません。");

--- a/src/components/configure/ConfigureMain.vue
+++ b/src/components/configure/ConfigureMain.vue
@@ -3,7 +3,7 @@
     <div id="configure-title">
       <h2>Configure</h2>
     </div>
-    <h3 class="configure-context-title">Key Config</h3>
+    <h3 class="configure-context-title" @click="confirmCustomKeys">Key Config</h3>
     <div id="configure-uploader">
       <configure-uploader :msg="confTitle" @file-recieve="onConfFileRecieve"></configure-uploader>
       <div class="start-btn btn-gray" @click="download"><u>↓</u> DL</div>
@@ -89,6 +89,16 @@ export default defineComponent({
         document.body.appendChild(obj);
         obj.click();
         obj.parentNode?.removeChild(obj);
+      }
+    },
+
+    confirmCustomKeys() {
+      const storage = localStorage;
+      const configText = storage.getItem("customKeyConfig") || "";
+      if (configText === "") {
+        alert("インポート済みのカスタムキー定義はありません。");
+      } else {
+        alert(`インポート済みのキー: ${Object.keys(JSON.parse(configText)).join(", ")}`);
       }
     },
 

--- a/src/components/configure/ConfigureMain.vue
+++ b/src/components/configure/ConfigureMain.vue
@@ -58,9 +58,7 @@ export default defineComponent({
 
               Object.assign(customKeyConfigBase, customKeyConfigNew);
               if (dupliKeyStr !== ``) {
-                if (
-                  !window.confirm(`すでに定義済みのキー設定があります。上書きしてもよろしいですか？\r\n[対象キー:${dupliKeyStr}]`)
-                ) {
+                if (!window.confirm(`定義済みのキー設定があります。上書きしてもよろしいですか？\r\n[対象キー:${dupliKeyStr}]`)) {
                   importFlg = false;
                 }
               }

--- a/src/components/configure/ConfigureMain.vue
+++ b/src/components/configure/ConfigureMain.vue
@@ -7,6 +7,7 @@
     <div id="configure-uploader">
       <configure-uploader :msg="confTitle" @file-recieve="onConfFileRecieve"></configure-uploader>
       <div class="start-btn btn-gray" @click="resetConf">RESET</div>
+      <div class="start-btn btn-gray" @click="download"><u>↓</u> DL</div>
     </div>
     <configure-design></configure-design>
     <div id="start-go-next">
@@ -48,8 +49,10 @@ export default defineComponent({
           const result = reader.result;
           if (typeof result == "string") {
             try {
-              JSON.parse(result);
-              storage.setItem("customKeyConfig", result);
+              const customKeyConfigNew = JSON.parse(result);
+              const customKeyConfigBase = JSON.parse(storage.getItem("customKeyConfig") || "");
+              Object.assign(customKeyConfigBase, customKeyConfigNew);
+              storage.setItem("customKeyConfig", JSON.stringify(customKeyConfigBase, null, 2));
               alert("コンフィグファイルをインポートしました。");
             } catch {
               alert("内容がJSON形式になっていません。");
@@ -58,6 +61,19 @@ export default defineComponent({
         };
         reader.readAsText(file);
       }
+    },
+
+    download() {
+      const storage = localStorage;
+      const configText = storage.getItem("customKeyConfig") || "";
+      const blob = new Blob([configText], { type: "text/plain" });
+      const obj = document.createElement("a");
+      obj.href = window.URL.createObjectURL(blob);
+      obj.download = `editorConfig_${new Date().toLocaleString()}.txt`;
+      obj.style.display = "none";
+      document.body.appendChild(obj);
+      obj.click();
+      obj.parentNode?.removeChild(obj);
     },
 
     resetConf() {

--- a/src/components/configure/ConfigureMain.vue
+++ b/src/components/configure/ConfigureMain.vue
@@ -50,10 +50,18 @@ export default defineComponent({
           if (typeof result == "string") {
             try {
               const customKeyConfigNew = JSON.parse(result);
-              const customKeyConfigBase = JSON.parse(storage.getItem("customKeyConfig") || "");
+              const customKeyConfigBase = JSON.parse(storage.getItem("customKeyConfig") || "{}");
+              const baseLength = Object.keys(customKeyConfigBase).length;
               Object.assign(customKeyConfigBase, customKeyConfigNew);
-              storage.setItem("customKeyConfig", JSON.stringify(customKeyConfigBase, null, 2));
-              alert("コンフィグファイルをインポートしました。");
+              if (baseLength + Object.keys(customKeyConfigNew).length > Object.keys(customKeyConfigBase).length) {
+                if (window.confirm("すでに定義済みのカスタムキー設定があります。上書きしてもよろしいですか？")) {
+                  storage.setItem("customKeyConfig", JSON.stringify(customKeyConfigBase, null, 2));
+                  alert("コンフィグファイルをインポートしました。");
+                }
+              } else {
+                storage.setItem("customKeyConfig", JSON.stringify(customKeyConfigBase, null, 2));
+                alert("コンフィグファイルをインポートしました。");
+              }
             } catch {
               alert("内容がJSON形式になっていません。");
             }
@@ -66,20 +74,26 @@ export default defineComponent({
     download() {
       const storage = localStorage;
       const configText = storage.getItem("customKeyConfig") || "";
-      const blob = new Blob([configText], { type: "text/plain" });
-      const obj = document.createElement("a");
-      obj.href = window.URL.createObjectURL(blob);
-      obj.download = `editorConfig_${new Date().toLocaleString()}.txt`;
-      obj.style.display = "none";
-      document.body.appendChild(obj);
-      obj.click();
-      obj.parentNode?.removeChild(obj);
+      if (configText === "") {
+        alert("カスタムキー定義がありません。");
+      } else {
+        const blob = new Blob([configText], { type: "text/plain" });
+        const obj = document.createElement("a");
+        obj.href = window.URL.createObjectURL(blob);
+        obj.download = `editorConfig_${new Date().toLocaleString()}.txt`;
+        obj.style.display = "none";
+        document.body.appendChild(obj);
+        obj.click();
+        obj.parentNode?.removeChild(obj);
+      }
     },
 
     resetConf() {
-      const storage = localStorage;
-      storage.removeItem("customKeyConfig");
-      alert("キー設定をリセットしました。");
+      if (window.confirm("カスタムキー設定をリセットします。よろしいですか？")) {
+        const storage = localStorage;
+        storage.removeItem("customKeyConfig");
+        alert("キー設定をリセットしました。");
+      }
     },
   },
 });

--- a/src/components/configure/ConfigureMain.vue
+++ b/src/components/configure/ConfigureMain.vue
@@ -6,8 +6,8 @@
     <h3 class="configure-context-title">Key Config</h3>
     <div id="configure-uploader">
       <configure-uploader :msg="confTitle" @file-recieve="onConfFileRecieve"></configure-uploader>
-      <div class="start-btn btn-gray" @click="resetConf">RESET</div>
       <div class="start-btn btn-gray" @click="download"><u>↓</u> DL</div>
+      <div class="start-btn btn-gray" @click="resetConf">RESET</div>
     </div>
     <configure-design></configure-design>
     <div id="start-go-next">


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
### 1. Config画面から設定できるカスタム定義のダウンロード機能を実装
- 現在登録しているカスタム定義をダウンロードする機能を実装しました。
- 自動整形した状態でダウンロードされます。
（厳密には、カスタム定義をアップロードすると以後、ダウンロード時に自動整形されるようになります）

### 2. カスタム定義の差分アップロードを実装
- 挙動的に、これまではファイルの全入れ替えとなっているようでした。
- 差分アップロード可能とし、同一キーが存在した場合は確認メッセージを出したうえで上書きするようにしました。
（5keyや7keyなどの既存キーに対してアップロードを行った場合も確認メッセージが出ます）
- 今後は追加したいキー定義だけアップロードすれば既存分が消えることはありません。

### 3. カスタムキー定義をリセットした場合の確認メッセージを追加
- 「RESET」ボタンを押したときに一度確認メッセージを入れるようにしました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
1. 現在設定されているエディターキー定義が何かがわからないため。
また、現状はJSON形式のチェックはあっても中身のチェックが無いので、ダウンロード機能を設けることで
設定の間違いがあったときに気づきやすくなると思われます。
2. 後からアップロードしたエディターキー定義を増やすことがありえるため。
また、既存キーとの重複チェックを入れることで設定間違いを確認できるため。
3. 間違って「RESET」ボタンを押してデータを消してしまう可能性があるため。

## :camera: スクリーンショット / Screenshot
<img src="https://github.com/user-attachments/assets/80637d87-e9d8-4ac8-a757-6e485eb424be" width="40%"><img src="https://github.com/user-attachments/assets/fd8ce33d-cf47-4dae-aa4b-dedd7eee7b6a" width="50%">


<img src="https://github.com/user-attachments/assets/812a7940-5ba3-4560-a236-188ba3afa75a" width="40%">

<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->

- ダウンロードデータサンプル
```
{
  "6": {
    "id": 600,
    "num": 6,
    "chars": [
      "J",
      "I",
      "K",
      "O",
      "L",
      "G"
    ],
    "keys": [
      "KeyJ",
      "KeyI",
      "KeyK",
      "KeyO",
      "KeyL",
      "KeyG"
    ],
    "alternativeKeys": [
      "KeyS",
      "KeyE",
      "KeyD",
      "KeyR",
      "KeyF",
      "KeyH"
    ],
    "noteNames": [
      "left_data",
      "leftdia_data",
      "down_data",
      "rightdia_data",
      "right_data",
      "space_data"
    ],
    "freezeNames": [
      "frzLeft_data",
      "frzLdia_data",
      "frzDown_data",
      "frzRdia_data",
      "frzRight_data",
      "frzSpace_data"
    ],
    "colorGroup": [
      0,
      1,
      0,
      1,
      0,
      2
    ]
  }
}
```

## :pencil: その他コメント / Other Comments
- いろいろPR出してしまいすみません。
- これを含め、他に出しているPRとは非依存になるように作っています。よろしくお願いします。
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
