### PR TITLE
fix: Key Configのリセット後、リロードしないと反映されない問題の修正

### DIFF
--- a/src/components/common/createCustomKeyConfig.ts
+++ b/src/components/common/createCustomKeyConfig.ts
@@ -5,7 +5,7 @@ export function createCustomKeyConfig(): CustomKeyConfig {
   let keyConfig: KeyConfig;
   if (customKeyConfigStr) {
     const obj = JSON.parse(customKeyConfigStr) as CustomKeyConfig;
-    keyConfig = Object.assign(DefaultKeyConfig, obj);
+    keyConfig = Object.assign({ ...DefaultKeyConfig }, obj);
   } else {
     keyConfig = DefaultKeyConfig;
   }


### PR DESCRIPTION
たぶん誤記？
DefaultKeyConfigがObject.assignで上書きされていました