### PR TITLE
fix: Load画面で貼り付けできない問題の修正

### DIFF
--- a/src/components/start/StartLoad.vue
+++ b/src/components/start/StartLoad.vue
@@ -10,7 +10,7 @@
       </div>
     </div>
     <div id="save-key-phrase" class="save-item-container">
-      <input v-model.trim="inputKeyPhrase" type="text" max="50" class="uk-input uk-form-small" list="phrase-history" />
+      <input v-model.trim="inputKeyPhrase" type="text" max="50" class="uk-input uk-form-small" list="phrase-history" @keydown="keydownAction"/>
       <datalist id="phrase-history">
         <option v-for="p in phraseHistory" :key="p">{{ p }}</option>
       </datalist>
@@ -58,6 +58,9 @@ export default defineComponent({
     resetForm() {
       this.keyPhrase = "";
     },
+    keydownAction(e: Event) {
+      e.stopPropagation()
+    }
   },
 });
 </script>


### PR DESCRIPTION
StartLoad画面でキーフレーズを貼り付けようとするとStartMain画面の貼り付け操作が優先されてしまう状態になっていました。
キーフレーズのinputのkeydownイベントにstopPropagationを入れて親画面に伝搬しないように修正しました。