### PR TITLE
fix: タッチ時にフォーカスが移るようにする

### DIFF
--- a/src/components/editor/EditorMain.vue
+++ b/src/components/editor/EditorMain.vue
@@ -751,6 +751,7 @@ export default defineComponent({
 
     // タッチ開始時
     touchStartAction(e: TouchEvent): void {
+      if (this.$refs.canvas instanceof HTMLElement) this.$refs.canvas.focus();
       if (!this.isClick) return;
       Array.from(e.changedTouches).forEach((touch) => {
         // 一定時間後に長押しとして処理する


### PR DESCRIPTION
ブラウザ依存っぽいですが、メイン画面をタッチしてもフォーカスが移らず、マウスが無い環境だと一度フォーカスが外れたら戻せなくなってしまう場合があります。
touchStartイベント発生時に強制的にフォーカスするように変更しました。

発生を確認した環境は以下です。
- Windows版Chrome150.0.7871.47 (開発者モードのデバイスモードで確認)
- iPad OS 26.5のSafari

タブレット+キーボードで作譜できると出先で便利なので取り込んでいただけるとありがたいです。
よろしくお願いします。